### PR TITLE
Added github/travis coverage hooks, for when we have istanbul integrated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,17 @@ branches:
         - master
 
 before_install: npm install -g linklocal;
-# travis runs 'npm install' by default, as the install step
+# travis runs 'npm install' by default, as the 'install' step
 
 before_script: linklocal -r; npm run dist;
-# travis runs 'npm test' by default, as the script step
+# travis runs 'npm test' by default, as the 'script' step
 
+# PLACEHOLDER FOR COVERAGE REPORTS ON GITHUB, IF WE WANT THEM.
+# ALSO NEED TO ADD .coveralls.yml, IF WE WANT TO USE IT ON THE PRIVATE 
+# REPO.
+
+# after_script:
+#  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 notifications:
     email:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "benchmarks": "^0.1.2",
     "chai": "~1.9.1",
     "colors": "~0.6.2",
+    "coveralls": "^2.11.2",
     "diff": "~1.0.8",
     "express": "~4.9.0",
     "falcor-browser": "git+ssh://git@github.com/Netflix/falcor-browser.git#v0.0.1",


### PR DESCRIPTION
If we want to test this with the private repo, will need additional `.coveralls.yml` config, otherwise we're good to go, once we start generating the lcov report from Istanbul.
