### PR TITLE
ignoring *.js was not a good idea

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -7,6 +7,7 @@
     "./macros/**",
     "./performance/**",
     "./test/**",
-    "*.js"
+    "./gulpfile.js",
+    "./server.js"
   ]
 }


### PR DESCRIPTION
I thought it implied local dir without the **/ 
