### PR TITLE
chore(package.json): use dist, main doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "falcor",
   "version": "0.0.7",
-  "main": "index-node",
+  "main": "./dist/Falcor.js",
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js test-coverage",
     "dist": "./node_modules/gulp/bin/gulp.js build"


### PR DESCRIPTION
currently `falcor-browser` requires `falcor` which is version v0.0.7 without `index-node.js` file. Manually editing the `package.json` inside of `falcor-browser`'s version `falcor` allows me to run `falcor` tests. (node 0.12.0, npm 2.7.6)
https://github.com/Netflix/falcor/blob/v0.0.7/package.json#L4
