### PR TITLE
Removing version number from dependent falcor packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "coveralls": "^2.11.2",
     "diff": "~1.0.8",
     "express": "~4.9.0",
-    "falcor-browser": "git+ssh://git@github.com/Netflix/falcor-browser.git#v0.0.4",
-    "falcor-server": "git+ssh://git@github.com/Netflix/falcor-server.git#v0.0.10",
+    "falcor-browser": "git+ssh://git@github.com/Netflix/falcor-browser.git",
+    "falcor-server": "git+ssh://git@github.com/Netflix/falcor-server.git",
     "gulp": "~3.8.8",
     "gulp-beautify": "~1.1.0",
     "gulp-bench": "~1.0.3",
@@ -54,7 +54,7 @@
   "dependencies": {
     "rx": "^2.3.25",
     "promise": "7.0.0",
-    "falcor-observable": "git+ssh://git@github.com/Netflix/falcor-observable.git#v0.1.1",
-    "falcor-path-syntax": "git+ssh://git@github.com/Netflix/falcor-path-syntax.git#v0.1.5"
+    "falcor-observable": "git+ssh://git@github.com/Netflix/falcor-observable.git",
+    "falcor-path-syntax": "git+ssh://git@github.com/Netflix/falcor-path-syntax.git"
   }
 }


### PR DESCRIPTION
While we are doing rapid development (and the repo is private) there's no need to fix to a version of the falcor-\* dependencies.
