### PR TITLE
Serialize bound path when model is converted to JSON

### DIFF
--- a/lib/falcor/Model.js
+++ b/lib/falcor/Model.js
@@ -287,5 +287,8 @@ Model.prototype = {
             throw new Error("Model#" + name + " may only be called within the context of a request selector.");
         }
         return true;
+    },
+    toJSON: function() {
+        return this._path;
     }
 };


### PR DESCRIPTION
In order to support passing models as parameters to call, I convert every model to it's bound path during JSON serialization.
