### PR TITLE
getCache accepts paths to serialize only parts of the cache.

### DIFF
--- a/lib/falcor/Model.js
+++ b/lib/falcor/Model.js
@@ -154,10 +154,21 @@ Model.prototype = {
         return this;
     },
     getCache: function() {
-        var pathmaps = [{}];
-        var tmpCache = this.boxValues().treatErrorsAsValues().materialize();
-        tmpCache._getPathMapsAsPathMap(tmpCache, [{ json: tmpCache._cache }], pathmaps);
-        return pathmaps[0].json;
+        var paths = slice.call(arguments);
+        if(paths.length == 0) {
+            paths[0] = { json: this._cache };
+        }
+        var result;
+        this.get.apply(this.
+                withoutDataSource().
+                boxValues().
+                treatErrorsAsValues().
+                materialize(), paths).
+            toJSONG().
+            subscribe(function(envelope) {
+                result = envelope.jsong;
+            });
+        return result;
     },
     getValueSync: function(path) {
         path = pathSyntax.fromPath(path);

--- a/test/falcor/get/get.getCache.spec.js
+++ b/test/falcor/get/get.getCache.spec.js
@@ -31,6 +31,39 @@ describe('getCache', function() {
                 }
             });
     });
+    
+    it("should serialize part of the cache", function(done) {
+        var model = new Model({ cache: {
+            "list": {
+                "0": "foo",
+                "1": "bar",
+                "2": Model.ref("lists.baz")
+            },
+            "lists": {
+                "baz": {
+                    "bam": "bam"
+                }
+            }
+        }});
+        
+        var partial = model.getCache(["list", [0, 1]], ["list", 2, "bam"]);
+        testRunner.compare({
+            "list": {
+                "0": Model.atom("foo"),
+                "1": Model.atom("bar"),
+                "2": Model.ref("lists.baz")
+            },
+            "lists": {
+                "baz": {
+                    "bam": Model.atom("bam")
+                }
+            } },
+            partial,
+            "Serialized cache should be value equal to the original.",
+            {strip: ["$size"]}
+        );
+        done();
+    });
 
     it('should test the cache again against the example by jafar.', function() {
          var $ref = falcor.Model.ref;


### PR DESCRIPTION
Fixes #181.
