### PR TITLE
Added ESLint rules we've decided on until now : ~6500 errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,136 @@
 {
+    "env": {
+        "browser": false,
+        "node": true,
+        "es6": false
+    },
     "rules": {
-        "no-underscore-dangle"  : 0,
-        "quotes"                : 0,
-        "camelcase"             : 0
+        // possible errors
+        "comma-dangle": [ 2 ],
+        "no-cond-assign": [ 2 ],
+        "no-console": [ 2 ],
+        "no-constant-condition": [ 2 ],
+        "no-control-regex": [ 2 ],
+        "no-debugger": [ 2 ],
+        "no-dupe-args": [ 2 ],
+        "no-dupe-keys": [ 2 ],
+        "no-duplicate-case": [ 2 ],
+        "no-empty": [ 2 ],
+        "no-empty-class": [ 2 ],
+        "no-ex-assign": [ 2 ],
+        "no-extra-boolean-cast": [ 2 ],
+        "no-extra-semi": [ 2 ],
+        "no-func-assign": [ 2 ],
+        // this is for variable hoisting, not necessary if we use block scoped declarations
+        // "no-inner-declarations": [ 2, "both" ],
+        "no-invalid-regexp": [ 2 ],
+        "no-irregular-whitespace": [ 2 ],
+        "no-negated-in-lhs": [ 2 ],
+        // when IE8 dies
+        "no-reserved-keys": [ 0 ],
+        "no-regex-spaces": [ 2 ],
+        "no-sparse-arrays": [ 2 ],
+        "no-unreachable": [ 2 ],
+        "use-isnan": [ 2 ],
+        // should we enforce valid documentation comments?
+        // i.e., if you do documentation, do it right
+        // "valid-jsoc": [ 2 ],
+        "valid-typeof": [ 2 ],
+
+        // best practices
+        "block-scoped-var": [ 2 ],
+        // warning for now until we get them fixed
+        "consistent-return": [ 2 ],
+        "curly": [ 2 ],
+        "default-case": [ 2 ],
+        "dot-notation": [ [ 2 ], { "allowKeywords": true } ],
+        "eqeqeq": [ 2 ],
+        "guard-for-in": [ 2 ],
+        "no-alert": [ 2 ],
+        "no-caller": [ 2 ],
+        "no-div-regex": [ 2 ],
+        "no-eq-null": [ 2 ],
+        "no-eval": [ 2 ],
+        "no-extend-native": [ 2 ],
+        "no-extra-bind": [ 2 ],
+        "no-fallthrough": [ 2 ],
+        "no-floating-decimal": [ 2 ],
+        "no-implied-eval": [ 2 ],
+        "no-iterator": [ 2 ],
+        "no-labels": [ 2 ],
+        "no-lone-blocks": [ 2 ],
+        "no-loop-func": [ 2 ],
+        "no-multi-spaces": [ 0 ],
+        "no-native-reassign": [ 2 ],
+        "no-new": [ 0 ],
+        "no-new-func": [ 2 ],
+        "no-new-wrappers": [ 2 ],
+        "no-octal": [ 2 ],
+        "no-octal-escape": [ 2 ],
+        "no-param-reassign": [ 2 ],
+        "no-proto": [ 2 ],
+        "no-process-env": [ 2 ],
+        "no-redeclare": [ 2 ],
+        "no-return-assign": [ 2 ],
+        "no-script-url": [ 2 ],
+        "no-self-compare": [ 2 ],
+        "no-sequences": [ 2 ],
+        "no-throw-literal": [ 2 ],
+        "no-unused-expressions": [ 2 ],
+
+        "no-warning-comments": [ 1 ],
+        "no-with": [ 2 ],
+        "radix": [ 2 ],
+        "wrap-iife": [ 2 ],
+        "yoda": [ 0 ],
+
+        // strict mode
+        "strict": [ 2, "global" ],
+
+        // variables
+        "no-catch-shadow": [ 2 ],
+        "no-delete-var": [ 2 ],
+        "no-shadow": [ 2 ],
+        "no-shadow-restricted-names": [ 2 ],
+        "no-undef": [ 2 ],
+        "no-undef-init": [ 2 ],
+        "no-undefined": [ 2 ],
+        "no-unused-vars": [ 2, { "vars": "all", "args": "none" } ],
+        "no-use-before-define": [ 2, "nofunc" ],
+
+        // node.js
+        "handle-callback-err": [ 2, "^.*(e|E)rr" ],
+        "no-mixed-requires": [ 2 ],
+        "no-new-require": [ 2 ],
+        "no-path-concat": [ 2 ],
+        "no-process-exit": [ 0 ],
+
+        // ES6
+        "generator-star-spacing": [ 2, "after" ],
+
+        // stylistic
+	/* COMMENTING THESE OUT UNTIL WE GET CONCENSUS ON THEM        
+        "camelcase": [ 2, { "properties": "always" } ],
+        "eol-last": [ 2 ],
+        "key-spacing": [ 0 ],
+        "no-lonely-if": [ 2 ],
+        "no-array-constructor": [ 2 ],
+        "no-mixed-spaces-and-tabs": [ 2, "smart-tabs" ],
+        "no-nested-ternary": [ 2 ],
+        "no-new-object": [ 2 ],
+        "no-underscore-dangle": [ 0 ],
+        "no-trailing-spaces": [ 2 ],
+        "no-wrap-func": [ 2 ],
+        "semi": [ 2, "always" ],
+        "space-after-keywords": [ 2, "always" ],
+        "space-before-blocks": [ 2, "always" ],
+        "space-before-function-paren": [ 2, { "anonymous": "never", "named": "never" } ],
+        "space-infix-ops": [ 2 ],
+        "space-return-throw-case": [ 2 ],
+        "space-unary-ops": [ 2, { "words": true, "nonwords": false } ],
+        "spaced-line-comment": [ 2, "always", { "exceptions": [ "-", "+" ] } ],
+        "quotes": [ 2, "single", "avoid-escape" ],
+        "wrap-regex": [ 2 ]
+        */
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-bench": "~1.0.3",
     "gulp-clean": "~0.3.1",
     "gulp-concat": "~2.4.1",
-    "gulp-eslint": "^0.7.0",
+    "gulp-eslint": "0.x",
     "gulp-istanbul": "~0.3.1",
     "gulp-istanbul-enforcer": "~1.0.3",
     "gulp-license": "~1.0.0",


### PR DESCRIPTION
@michaelbpaulson @trxcllnt @jhusain 

These are the set of ESLint rules we've consciously decided on so far as a team.

Basically everything through the  commented out stylistic section is what we've consciously decided on (cc @msweeney @DonutEspresso [Alex]).

Approx ~6500 errors based on these settings so far.

I also updated `package.json` since we were stuck on an older version of gulp-eslint (and hence eslint) which didn't support all the new settings. `npm update` should update you to the latest.

See #168
