### PR TITLE
Uncommented stylistic section. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,7 +109,6 @@
         "generator-star-spacing": [ 2, "after" ],
 
         // stylistic
-	/* COMMENTING THESE OUT UNTIL WE GET CONCENSUS ON THEM        
         "camelcase": [ 2, { "properties": "always" } ],
         "eol-last": [ 2 ],
         "key-spacing": [ 0 ],
@@ -131,6 +130,5 @@
         "spaced-line-comment": [ 2, "always", { "exceptions": [ "-", "+" ] } ],
         "quotes": [ 2, "single", "avoid-escape" ],
         "wrap-regex": [ 2 ]
-        */
     }
 }


### PR DESCRIPTION
Better to start with the current thinking, than defaults. Note, as mentioned, we haven't reached consensus on the stylistic section yet, but this is the current set of values we have as a starting point.

It has `no_underscore_dangle` disabled, but requires for example, consistency around quoting strings.

This bumps up the errors to ~7500.

@michaelbpaulson @dzannotti @jhusain 
