### PR TITLE
fix(Model): ensure correct constructor

### DIFF
--- a/lib/falcor/Model.js
+++ b/lib/falcor/Model.js
@@ -95,6 +95,9 @@ Model.atom = function(value) {
 };
 
 Model.prototype = {
+    // because javascript
+    constructor: Model,
+    
     _boxed: false,
     _progressive: false,
     _errorSelector: function(x, y) { return y; },


### PR DESCRIPTION
closes #273

we should also be extending the prototype rather than replacing it

``` es6
Model.prototype = {
  constructor: Model
}
// should be
extend(Model.prototype, {
  constructor: Model
})
```
