### PR TITLE
Added workaround for RSJS Webpack bug (specified in file)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  resolve: {
+    alias: {
+      // Workaround https://github.com/Reactive-Extensions/RxJS/issues/832, until it's fixed
+      'rx$': require.resolve('rx/dist/rx')
+    }
+  }
+};


### PR DESCRIPTION
The RxJS bug is here: https://github.com/Reactive-Extensions/RxJS/issues/832
The Details/Repo are here: https://github.com/sdesai/rxjs-webpack-test

It addresses part of issue: https://github.com/Netflix/falcor/issues/338

This will let folks build 'falcor' with webpack and have the bundle work (it'll send out requests).

Still need to provide the right advice for people who include 'falcor' as a dependency and want to build with WebPack, until the RxJS bug is fixed, because defining a webpack.config.js entry for them, along the same lines, would require them to reach into `node_modules/falcor/node_modules/rx/dist/rx` which does work, but is a little ugly.
