### PR TITLE
Added script to transform perf CSV results to averages for CI plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "~1.9.1",
     "colors": "~0.6.2",
     "coveralls": "^2.11.2",
+    "csv-parse": "^0.1.3",
     "diff": "~1.0.8",
     "express": "~4.9.0",
     "falcor-browser": "git+ssh://git@github.com/Netflix/falcor-browser.git",

--- a/performance/scripts/transformCSV.js
+++ b/performance/scripts/transformCSV.js
@@ -1,0 +1,64 @@
+var fs = require('fs');
+var parse = require('csv-parse');
+var minimist = require('minimist');
+var argv = minimist(process.argv.slice(2));
+
+if (argv._.length < 2) {
+    console.log('node transformCSV.js <inputFile.csv> <outputFile.csv>');
+    process.exit(9);
+}
+
+var input = fs.createReadStream(argv._[0]);
+var output = fs.createWriteStream(argv._[1]);
+
+function isNumber(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+var parser = parse({trim:true}, function(err, data) {
+
+    var headers = 0;
+    var rows = 0;
+
+    var transformed = data.reduce(function(prev, current) {
+
+        var header = prev[0];
+        var avg = prev[1];
+
+        var firstCell = current[0];
+
+        if (!isNumber(firstCell)) {
+            if (header) {
+                prev[0] = header.map(function(headerValue, idx) {
+                    return headerValue + ":" + current[idx];
+                });
+            } else {
+                prev[0] = current.concat();
+            }
+
+            headers = headers + 1;
+
+        } else {
+
+            if (avg) {
+                prev[1] = avg.map(function(value, idx) {
+                    // Running Average
+                    return ((value * rows) + parseFloat(current[idx]))/(rows + 1);
+                });
+            } else {
+                prev[1] = current.map(function(v) { return parseFloat(v); });
+            }
+
+            rows = rows + 1;
+        }
+
+        return prev;
+
+    }, []);
+
+    output.write(transformed.reduce(function(prev, current) {
+        return prev + '\n' + current.join(',');
+    }, ''));
+});
+
+input.pipe(parser);


### PR DESCRIPTION
@michaelbpaulson 

For CI runs, we needed a simpler set of values to plot build over build for comparison.

Added a script to generate averages from the individual run data we currently capture for performance tests [ which catered to the manual import/reporting we were using ]

So, we go from, for example:

| JSON | PathMap | JSON | PathMap |
| --- | --- | --- | --- |
| simple | simple | reference | reference |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |

To:

| JSON:simple | PathMap:simple | JSON:reference | PathMap:reference |
| --- | --- | --- | --- |
| 1111.11 | 2222.22 | 3333.33 | 4444.44 |

Which we can then plot build over build
