### PR TITLE
Fix last eslint error

### DIFF
--- a/lib/lru/collect.js
+++ b/lib/lru/collect.js
@@ -19,7 +19,7 @@ module.exports = function collect(lru, expired, total, max, ratio, version) {
     var targetSize = max * ratio;
     var parent, node, size;
 
-    while(!!(node = expired.pop())) {
+    while (node = expired.pop()) {
         size = node.$size || 0;
         total -= size;
         if(shouldUpdate === true) {


### PR DESCRIPTION
Ran eslint and found one remaining error.

Eslint didn't like the double negation, so when it was removed eslint was happy again, and all tests were still passing.
