### PR TITLE
Fix "a" to "an" across multiple files

### DIFF
--- a/build/falcor.browser.js
+++ b/build/falcor.browser.js
@@ -1413,7 +1413,7 @@ function getWalk(model, root, curr, pathOrJSON, depthArg, seedOrFunction, positi
         var atEndOfJSONQuery = false;
         var keySet, i, len;
         if (jsonQuery) {
-            // it has a $type property means we have hit a end.
+            // it has a $type property means we have hit an end.
             if (pathOrJSON && pathOrJSON.$type) {
                 atEndOfJSONQuery = true;
             }
@@ -7146,7 +7146,7 @@ module.exports = function mergeNode(roots, parent, nodeArg, messageParent, messa
             updateGraph(parent, offset, roots.version, roots.lru);
             node = graphNode(roots[0], parent, node, key, roots.version);
         }
-        // Otherwise, cache and message are the same primitive value. Wrap in a atom and insert.
+        // Otherwise, cache and message are the same primitive value. Wrap in an atom and insert.
         else {
             roots.isDistinct = true;
             node = parent[key] = wrapNode(node, type, node);
@@ -11867,7 +11867,7 @@ Promise.prototype.nodeify = function (callback, ctx) {
 
   /**
    * Returns an observable sequence that is the result of invoking the selector on a connectable observable sequence that shares a single subscription to the underlying sequence containing only the last notification.
-   * This operator is a specialization of Multicast using a AsyncSubject.
+   * This operator is a specialization of Multicast using an AsyncSubject.
    *
    * @example
    * var res = source.publishLast();

--- a/doc/docs.js.html
+++ b/doc/docs.js.html
@@ -689,7 +689,7 @@ var model = new falcor.Model({
     cache: {
         user: {
             name: {
-                // Metadata that indicates this object is a Atom
+                // Metadata that indicates this object is an Atom
                 $type: "atom",
                 // The value property contains the value box by the Atom
                 value: "Jim Parsons",
@@ -1504,7 +1504,7 @@ var nameAndRatings =
 //   }
 // }
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;
@@ -1595,7 +1595,7 @@ model.setCache(
         }
     });
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;
@@ -1691,7 +1691,7 @@ model.setCache(
         }
     });
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;
@@ -1964,7 +1964,7 @@ model.setCache(
         }
     });
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;
@@ -2499,7 +2499,7 @@ var model = new falcor.Model();
 model.setCache({
     user: {
         name: {
-            // Metadata that indicates this object is a Atom
+            // Metadata that indicates this object is an Atom
             $type: "atom",
             // The value property contains the value box by the Atom
             value: "Jim Parsons",
@@ -2530,7 +2530,7 @@ var model = new falcor.Model();
 model.setCache({
     user: {
         name: {
-            // Metadata that indicates this object is a Atom
+            // Metadata that indicates this object is an Atom
             $type: "atom",
             // The value property contains the value box by the Atom
             value: "Jim Parsons",
@@ -2637,7 +2637,7 @@ model.setCache(
         }
     });
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;
@@ -2845,7 +2845,7 @@ model.setCache(
         }
     });
 
-// Converts a integer into a string of stars
+// Converts an integer into a string of stars
 function getStars(num) {
     var stars = "",
         counter;

--- a/documentation/router.md
+++ b/documentation/router.md
@@ -503,7 +503,7 @@ var Observable = Rx.Observable;
 }
 ~~~
 
-An Observable is similar to a Promise, with the principal difference being that an Observable can send multiple values over time. The main advantage of using a Observable over a Promise is the ability to progressively return PathValues to the Router as soon as they are returned from the underlying DataSource.  In contrast, when delivering values in a Promise, all values must be collected together in a JSON Graph envelope or an Array of PathValues and returned to the Router at the same time.
+An Observable is similar to a Promise, with the principal difference being that an Observable can send multiple values over time. The main advantage of using an Observable over a Promise is the ability to progressively return PathValues to the Router as soon as they are returned from the underlying DataSource.  In contrast, when delivering values in a Promise, all values must be collected together in a JSON Graph envelope or an Array of PathValues and returned to the Router at the same time.
  
 Using an Observable can improve throughput, because Routers may make additional requests to backend services in the event references are discovered in a Route Handler's JSON Graph output.
 
@@ -741,7 +741,7 @@ In this section we will examine how the router executes each of the DataSource m
 
 ## Walkthrough: Building a Router for Netflix-like Application
 
-Netflix is a online streaming video service with millions of subscribers.  When a member logs on to the Netflix service, they are presented with a list of genres, each of which contains a list of titles which they can stream.
+Netflix is an online streaming video service with millions of subscribers.  When a member logs on to the Netflix service, they are presented with a list of genres, each of which contains a list of titles which they can stream.
 
 ![Netflix Homepage](http://netflix.github.io/falcor/images/netflix-screenshot.png)
 


### PR DESCRIPTION
For aeiou, I did a global search for:
" a a", " a e", " a i", " a o", " a u" (case insensitive) (for middle/end of sentences)
"A a", "A e", "A i", "A o", "A u" (case sensitive) (for beginning of sentences)
"a [a", "a [e", "a [i", "a [o", "a [u" (case insensitive) (for hyperlinks)
