### PR TITLE
Alter facebook share image url to avoid fb crawler issue

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,10 +1,11 @@
 {% capture page_title %}{%if page.title %}{{ site.meta_defaults.title_prefix }}{{ page.title }}{% else %}{{ site.meta_defaults.title_prefix }}{{ site.meta_defaults.title }}{% endif %}{% endcapture %}
 {% capture page_description %}{%if page.description %}{{ page.description }}{% else %}{{ site.meta_defaults.description }}{% endif %}{% endcapture %}
 {% capture site_sharing_image %}https://netflix.github.io{{ site.baseurl }}/images/falcor-logo.png{% endcapture %}
-{% capture site_sharing_image_open_graph %}https://netflix.github.io{{ site.baseurl }}/images/falcor-logo-og.png{% endcapture %}
+{% capture site_sharing_image_open_graph %}http://netflix.github.io{{ site.baseurl }}/images/falcor-logo-og.png{% endcapture %}
+{% capture site_sharing_image_open_graph_secure %}https://netflix.github.io{{ site.baseurl }}/images/falcor-logo-og.png{% endcapture %}
 {% assign site_social_handle = "@netflixoss" %}
 {% assign company_social_handle = "@netflix" %}
-{% capture site_url %}https://netflix.github.io{{ site.baseurl }}/{% endcapture %}
+{% capture page_url %}https://netflix.github.io{{ site.baseurl }}{{ page.url }}{% endcapture %}
 
 {% comment %}
 The separate open graph image is necessary because facebook's share widget,
@@ -39,9 +40,9 @@ its wide aspect ratio.
 <meta property="og:title" content="{{ page_title }}">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Falcor" />
-<meta property="og:url" content="{{ site_url }}">
+<meta property="og:url" content="{{ page_url }}">
 <meta property="og:image" content="{{ site_sharing_image_open_graph }}">
-<meta property="og:image:secure_url" content="{{ site_sharing_image_open_graph }}" />
+<meta property="og:image:secure_url" content="{{ site_sharing_image_open_graph_secure }}" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:description" content="{{ page_description }}">


### PR DESCRIPTION
@jhusain (CC @ktrott @trxcllnt @sdesai @michaelbpaulson)

Turns out Facebook's debugger has, well, a bug :) This corrects the og:image tag so it's crawled properly by the crawler, instead of just crawled correctly by the debugger despite the main crawler being unable to crawl it.

Also updates og:url meta tag to point to the current page than site root, which the docs imply is the preferred usage.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netflix/falcor/415)
<!-- Reviewable:end -->
