### PR TITLE
adds missing closing bracket to template and html to correct typo

### DIFF
--- a/doc/Model.html
+++ b/doc/Model.html
@@ -1060,7 +1060,7 @@ or
     
             
 <div class="param-desc">
-    <p>{ModelResponse.<JSONEnvelope> - a JSONEnvelope contains the values returned from the function</p>
+    <p>ModelResponse.<JSONEnvelope> - a JSONEnvelope contains the values returned from the function</p>
 </div>
 
 

--- a/doc/Model.js.html
+++ b/doc/Model.js.html
@@ -251,7 +251,7 @@ Model.prototype._set = function _set() {
  * @param {Array.&lt;Object>} args - the arguments to pass to the function
  * @param {Array.&lt;PathSet>} refPaths - the paths to retrieve from the JSON Graph References in the message returned from the function
  * @param {Array.&lt;PathSet>} thisPaths - the paths to retrieve from function's this object after successful function execution
- * @returns {ModelResponse.&lt;JSONEnvelope> - a JSONEnvelope contains the values returned from the function
+ * @returns {ModelResponse.&lt;JSONEnvelope>} - a JSONEnvelope contains the values returned from the function
  */
 Model.prototype.call = function call() {
     var args;


### PR DESCRIPTION
"{" before ModelResponse was caused by missing closing bracket. Added closing bracket to template and removed "{" from generated html.
![capture2](https://cloud.githubusercontent.com/assets/6645733/9315610/eb799022-44e4-11e5-8d33-6a692a6e72e8.JPG)
