### PR TITLE
Minor clean ups

### DIFF
--- a/lib/ModelRoot.js
+++ b/lib/ModelRoot.js
@@ -1,4 +1,5 @@
 var isFunction = require("./support/is-function");
+var hasOwn = require("./support/hasOwn");
 var ImmediateScheduler = require("./schedulers/ImmediateScheduler");
 
 function ModelRoot(o) {
@@ -28,8 +29,7 @@ ModelRoot.prototype.errorSelector = function errorSelector(x, y) {
     return y;
 };
 ModelRoot.prototype.comparator = function comparator(a, b) {
-    if (Boolean(a) && typeof a === "object" && a.hasOwnProperty("value") &&
-        Boolean(b) && typeof b === "object" && b.hasOwnProperty("value")) {
+    if (hasOwn(a, "value") && hasOwn(b, "value")) {
         return a.value === b.value;
     }
     return a === b;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ function falcor(opts) {
     return new falcor.Model(opts);
 }
 
-if (typeof Promise !== "undefined" && Promise) {
+if (typeof Promise === "function") {
     falcor.Promise = Promise;
 } else {
     falcor.Promise = require("promise");

--- a/lib/support/hasOwn.js
+++ b/lib/support/hasOwn.js
@@ -1,0 +1,6 @@
+var isObject = require("./is-object");
+var hasOwn = Object.prototype.hasOwnProperty;
+
+module.exports = function(obj, prop) {
+  return isObject(obj) && hasOwn.call(obj, prop);
+};

--- a/lib/walk/walk-path-map-soft-link.js
+++ b/lib/walk/walk-path-map-soft-link.js
@@ -100,13 +100,11 @@ function walkPathMap(onNode, onValueType, pathmap, keysStack, depth, roots, pare
         var isBranch = isObject(pathmap2) && !pathmap2.$type; // && !isArray(pathmap2);
         if (isBranch) {
             for (childKey in pathmap2) {
-                if ((childKey[0] === prefix) || (childKey[0] === "$")) {
-                    continue;
+                if (childKey[0] !== prefix || childKey[0] !== "$") {
+                    isBranch = pathmap2.hasOwnProperty(childKey);
+                    break;
                 }
-                childKey = pathmap2.hasOwnProperty(childKey);
-                break;
             }
-            isBranch = childKey === true;
         }
 
         requested2 = arrayAppend(requested, innerKey);

--- a/lib/walk/walk-path-map.js
+++ b/lib/walk/walk-path-map.js
@@ -103,16 +103,13 @@ function walkPathMap(onNode, onValueType, pathmap, keysStack, depth, roots, pare
         var childKey = false;
 
         var isBranch = isObject(pathmap2) && !pathmap2.$type; // && !isArray(pathmap2);
-
         if (isBranch) {
             for (childKey in pathmap2) {
-                if ((childKey[0] === prefix) || (childKey[0] === "$")) {
-                    continue;
+                if (childKey[0] !== prefix || childKey[0] !== "$") {
+                    isBranch = pathmap2.hasOwnProperty(childKey);
+                    break;
                 }
-                childKey = pathmap2.hasOwnProperty(childKey);
-                break;
             }
-            isBranch = childKey === true;
         }
 
         if (innerKey === "null") {


### PR DESCRIPTION
Just a couple minor things I noticed could be easily refactored doing a once over

Out of curiousity, why did you decide to implement many of the support functions over using `lodash` module implementations?