### PR TITLE
Get rid of the protocol-relative URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now create an index.html file with the following contents:
 <html>
   <head>
     <!-- Do _not_  rely on this URL in production. Use only during development.  -->
-    <script src="//netflix.github.io/falcor/build/falcor.browser.js"></script>
+    <script src="https://netflix.github.io/falcor/build/falcor.browser.js"></script>
     <script>
       var model = new falcor.Model({source: new falcor.HttpDataSource('/model.json') });
       


### PR DESCRIPTION
> TLS has exactly one performance problem: it is not used widely enough. ([Source](https://istlsfastyet.com/))

[This example](https://github.com/Netflix/falcor#retrieving-data-from-the-virtual-json-resource) should not be influencing the use of **protocol-relative URLs**, as seen that is considered an anti-pattern nowadays. If an asset is available on HTTPS protocol, then it should be used as such, just as Google and jQuery does ([reference](https://github.com/konklone/cdns-to-https#background)).

HTTPS is ready enough.