### PR TITLE
Fixed example code in multiple route paths.

### DIFF
--- a/documentation/router.md
+++ b/documentation/router.md
@@ -86,7 +86,7 @@ var router = new Router([
                 getTodoList().
                 then(function(todoList) {
                     return pathSet[1].map(function(key) {
-                        return { path: ["todos", "name"], value: todoList.name };
+                        return { path: ["todos", key], value: todoList[key] };
                     });
                 });
         }


### PR DESCRIPTION
The key was previously ignored - it was always using "name"