### PR TITLE
fix(Model): fix batch with ._clone()

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -501,7 +501,7 @@ Model.prototype.batch = function batch(schedulerOrDelayArg) {
     } else if (!schedulerOrDelay || !schedulerOrDelay.schedule) {
         schedulerOrDelay = new ASAPScheduler();
     }
-    var clone = this.clone();
+    var clone = this._clone();
     clone._request = new RequestQueue(clone, schedulerOrDelay);
 
     return clone;


### PR DESCRIPTION
fixes #442

current workaround 
`falcor.Model.prototype.clone = falcor.Model.prototype._clone;`