### PR TITLE
export browser.js for browserify to require

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build",
     "dist",
     "lib",
+    "browser.js",
     "test"
   ],
   "keywords": [


### PR DESCRIPTION
When I require falcor and bundle with browserify, it dosen't require
in HttpDataSource, which I really want to bundle in my app.

the idea is by export the `browser.js` file so basically I can `require('falcor/browser')` instead.