### PR TITLE
Access all YouTube videos over HTTPS

### DIFF
--- a/_layouts/video-page.html
+++ b/_layouts/video-page.html
@@ -9,7 +9,7 @@ page_class: "video-page"
     <div class="row video-player">
       <div class="col-xs-12">
         <div class="embed-responsive embed-responsive-16by9">
-          <iframe allowfullscreen class="embed-responsive-item" src="http://www.youtube.com/embed/{{ page.youtube_id }}?rel=0"></iframe>        
+          <iframe allowfullscreen class="embed-responsive-item" src="https://www.youtube.com/embed/{{ page.youtube_id }}?rel=0"></iframe>        
         </div>        
       </div>
     </div>


### PR DESCRIPTION
@jhusain There were previously occasional issues when youtube videos were embedded with HTTPS on some devices, but they have hopefully been sorted out, because Chrome/FF are now completely blocking non-HTTPS youtube embeds. This remedies that going forward by upgrading them all to HTTPS embeds.