### PR TITLE
Delete unneeded .coveralls.yml config file

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: dwhgrXoFD3ngKausU7aQT5ote0gXrmv9h


### PR DESCRIPTION
Since the project is building on Travis, Coveralls will infer the repo token automatically.