### PR TITLE
Fixes CallResponse to prepend the bound path to the callPath when calling the data source.

### DIFF
--- a/lib/response/CallResponse.js
+++ b/lib/response/CallResponse.js
@@ -201,10 +201,6 @@ function subscribeToResponse(observer) {
         function pluckPath(pathValue) {
             return pathValue.path;
         }
-
-        function prependThisPath(path) {
-            return boundThisPath.concat(path);
-        }
     }
 
     function getRemoteCallObs(dataSource) {
@@ -213,7 +209,7 @@ function subscribeToResponse(observer) {
             return Rx.Observable.defer(function() {
                 var obs;
                 try {
-                    obs = dataSource.call(callPath, callArgs, suffixes, extraPaths);
+                    obs = dataSource.call(boundCallPath, callArgs, suffixes, extraPaths);
                 } catch (e) {
                     obs = Observable.throw(new InvalidSourceError(e));
                 }
@@ -243,6 +239,10 @@ function subscribeToResponse(observer) {
                     })
                 };
             });
+    }
+
+    function prependThisPath(path) {
+        return boundThisPath.concat(path);
     }
 }
 

--- a/test/falcor/call/call.spec.js
+++ b/test/falcor/call/call.spec.js
@@ -25,6 +25,21 @@ function getModel(newModel, cache) {
 }
 
 describe("Call", function() {
+
+    it("executes a remote call on a bound Model and sends the call and extra paths relative to the root", function(done) {
+        var model = getDataModel({
+            call: function(callPath, args, suffixes, extraPaths) {
+                expect(callPath).to.deep.equal(["lists", "add"]);
+                expect(extraPaths).to.deep.equal([[0, "summary"]]);
+                done();
+            }
+        }, Cache());
+        model
+            ._clone({ _path: ["lists"] })
+            .call(["add"], [], [], [[0, "summary"]])
+            .subscribe(noOp, noOp, noOp);
+    })
+
     it("executes a local function with the call args", function(done) {
 
         var model = getDataModel(new LocalDataSource(Cache()), ReducedCache());


### PR DESCRIPTION
@jhusain @michaelbpaulson caught this today, does this fix look correct?