### PR TITLE
merge jsonGraph with a null non sentinel value.

### DIFF
--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -3,6 +3,7 @@ var __parent = require("./../internal/parent");
 
 var $ref = require("./../types/ref");
 var $error = require("./../types/error");
+var $atom = require("./../types/atom");
 var getSize = require("./../support/getSize");
 var getTimestamp = require("./../support/getTimestamp");
 var isObject = require("./../support/isObject");
@@ -27,13 +28,31 @@ module.exports = function mergeJSONGraphNode(
         cTimestamp, mTimestamp;
 
     // If the cache and message are the same, we can probably return early:
-    // - If they're both null-sy, return null.
+    // - If they're both nullsy,
+    //   - If null then the node needs to be wrapped in an atom and inserted.
+    //     This happens from whole branch merging when a leaf is just a null value
+    //     instead of being wrapped in an atom.
+    //   - If undefined then return null (previous behavior).
     // - If they're both branches, return the branch.
     // - If they're both edges, continue below.
     if (node === message) {
-        if (node == null) {
+
+        // There should not be undefined values.  Those should always be
+        // wrapped in an $atom
+        if (message === null) {
+            node = wrapNode(message, undefined, message);
+            parent = updateNodeAncestors(parent, -node.$size, lru, version);
+            node = insertNode(node, parent, key);
+            promote(lru, node);
             return node;
-        } else {
+        }
+
+        // The messange and cache are both undefined, therefore return null.
+        else if (message === undefined) {
+            return null;
+        }
+
+        else {
             cIsObject = isObject(node);
             if (cIsObject) {
                 // Is the cache node a branch? If so, return the cache branch.

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -49,7 +49,7 @@ module.exports = function mergeJSONGraphNode(
 
         // The messange and cache are both undefined, therefore return null.
         else if (message === undefined) {
-            return null;
+            return message;
         }
 
         else {

--- a/performance/tests/get/get.core.perf.js
+++ b/performance/tests/get/get.core.perf.js
@@ -4,7 +4,7 @@ var row = [['lolomo', 0, {from: 0, to: 9}, 'item', 'title']];
 var complex = [['lolomo', {from: 0, to: 4}, {from: 0, to: 9}, 'item', 'title']];
 var noOp = function() {};
 var ImmediateScheduler = require("./../../../lib/schedulers/ImmediateScheduler");
-var CacheGenerator = require('./../../../test/CacheGenerator');
+var cacheGenerator = require('./../../../test/CacheGenerator');
 var cache = cacheGenerator(0, 50);
 var model = new Model({
     cache: cache
@@ -13,24 +13,13 @@ var model = new Model({
 model.get(complex[0]).subscribe(function(data) { });
 
 var getWithPathsAsPathMap = require('./../../../lib/get').getWithPathsAsPathMap;
+var out = {};
+for (var i = 0; i < 5; ++i) {
+    out['rowTest ' + i] = rowTest;
+}
 
-module.exports = {
-    'Test simple get': function() {
-        getWithPathsAsPathMap(model, simple, [{}]);
-    },
-    'Test simple get again': function() {
-        getWithPathsAsPathMap(model, simple, [{}]);
-    },
-    'Test row get': function() {
-        getWithPathsAsPathMap(model, row, [{}]);
-    },
-    'Test row get again': function() {
-        getWithPathsAsPathMap(model, row, [{}]);
-    },
-    'Test complex get': function() {
-        getWithPathsAsPathMap(model, complex, [{}]);
-    },
-    'Test complex get again': function() {
-        getWithPathsAsPathMap(model, complex, [{}]);
-    }
-};
+function rowTest() {
+    getWithPathsAsPathMap(model, row, [{}]);
+}
+
+module.exports = out;

--- a/performance/tests/get/get.perf.js
+++ b/performance/tests/get/get.perf.js
@@ -1,6 +1,7 @@
 var Model = require("./../../../lib").Model;
 var simple = ['lolomo', 0, 0, 'item', 'title'];
 var row = ['lolomo', 0, {from: 0, to: 9}, 'item', 'title'];
+var rows = [['lolomo', 0, {from: 0, to: 9}, 'item', 'title']];
 var complex = ['lolomo', {from: 0, to: 4}, {from: 0, to: 9}, 'item', 'title'];
 var noOp = function() {};
 var ImmediateScheduler = require("./../../../lib/schedulers/ImmediateScheduler");
@@ -23,79 +24,54 @@ var tail = require('./../../../lib/internal/tail');
 var next = require('./../../../lib/internal/next');
 var prev = require('./../../../lib/internal/prev');
 
-module.exports = {
-    'Tests getting primed cache results': function() {
-        model.
-            get(row).
-            subscribe(noOp, noOp, noOp);
-    },
-    'Tests getting primed cache results again': function() {
-        model.
-            get(row).
-            subscribe(noOp, noOp, noOp);
-    },
-    'Tests getting empty cache to dataSource results': function() {
-        triggerModel.
-            get(row).
-            subscribe(noOp, noOp, function() {
-                triggerModel._root.cache = {};
-                triggerModel._root[head] = null;
-                triggerModel._root[tail] = null;
-                triggerModel._root[prev] = null;
-                triggerModel._root[next] = null;
-                triggerModel._root.expired = [];
-            });
-            triggerSource.trigger();
-    },
-    'Tests getting empty cache to dataSource results again': function() {
-        triggerModel.
-            get(row).
-            subscribe(noOp, noOp, function() {
-                triggerModel._root.cache = {};
-                triggerModel._root[head] = null;
-                triggerModel._root[tail] = null;
-                triggerModel._root[prev] = null;
-                triggerModel._root[next] = null;
-                triggerModel._root.expired = [];
-            });
-            triggerSource.trigger();
-    },
+function primedCache() {
+    model.
+        get(row).
+        subscribe(noOp, noOp, noOp);
+}
 
-    'Batching Across Requests': function() {
-        triggerModel.
-            get(row).
-            subscribe(noOp, noOp, noOp);
+function primedCacheWithPaths() {
+    model.
+        getPaths(rows).
+        subscribe(noOp, noOp, noOp);
+}
 
-        triggerModel.
-            get(row).
-            subscribe(function() {
-            }, noOp, function() {
-                triggerModel._root.cache = {};
-                triggerModel._root[head] = null;
-                triggerModel._root[tail] = null;
-                triggerModel._root[prev] = null;
-                triggerModel._root[next] = null;
-                triggerModel._root.expired = [];
-            });
-            triggerSource.trigger();
-    },
-    'Batching Across Requests again': function() {
-        triggerModel.
-            get(row).
-            subscribe(noOp, noOp, noOp);
+function toDataSource() {
+    triggerModel.
+        get(row).
+        subscribe(noOp, noOp, function() {
+            triggerModel._root.cache = {};
+            triggerModel._root[head] = null;
+            triggerModel._root[tail] = null;
+            triggerModel._root[prev] = null;
+            triggerModel._root[next] = null;
+            triggerModel._root.expired = [];
+        });
+        triggerSource.trigger();
+}
 
-        triggerModel.
-            get(row).
-            subscribe(function() {
-            }, noOp, function() {
-                triggerModel._root.cache = {};
-                triggerModel._root[head] = null;
-                triggerModel._root[tail] = null;
-                triggerModel._root[prev] = null;
-                triggerModel._root[next] = null;
-                triggerModel._root.expired = [];
-            });
-            triggerSource.trigger();
-    }
-};
+function batchingRequests() {
+    triggerModel.
+        get(row).
+        subscribe(noOp, noOp, noOp);
+
+    triggerModel.
+        get(row).
+        subscribe(function() {
+        }, noOp, function() {
+            triggerModel._root.cache = {};
+            triggerModel._root[head] = null;
+            triggerModel._root[tail] = null;
+            triggerModel._root[prev] = null;
+            triggerModel._root[next] = null;
+            triggerModel._root.expired = [];
+        });
+        triggerSource.trigger();
+}
+
+var out = module.exports = {};
+
+for (var i = 0; i < 5; ++i) {
+    out['primed cache ' + i] = primedCache;
+}
 

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -9,7 +9,7 @@ var sinon = require('sinon');
 var noOp = function() {};
 var Router = require('falcor-router');
 
-describe.only('Get Integration Tests', function() {
+describe('Get Integration Tests', function() {
     var server;
     beforeEach(function(done) {
         var app = express();

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -1,0 +1,66 @@
+// This file starts the server and exposes the Router at /model.json
+var express = require('express');
+var FalcorServer = require('falcor-express');
+var falcor = require('./../../browser');
+var Model = falcor.Model;
+var HttpDataSource = falcor.HttpDataSource;
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var noOp = function() {};
+var Router = require('falcor-router');
+
+describe.only('Get Integration Tests', function() {
+    var server;
+    beforeEach(function(done) {
+        var app = express();
+
+        // Simple middleware to handle get/post
+        app.use('/model.json', FalcorServer.dataSourceRoute(function(req, res) {
+            return new Router([
+                {
+                    route: ['thing', 'prop'],
+                    get: function (path) {
+                        return {
+                            path: ['thing', 'prop'],
+                            value: null
+                        };
+                    }
+                }
+            ]);
+        }));
+
+        server = app.listen(1337, function(err) {
+            if (err) {
+                done(err);
+                return;
+            }
+            done();
+        });
+
+    });
+
+    it('should be able to return null from a router. #535', function(done) {
+        var model = new falcor.Model({
+            source: new falcor.HttpDataSource('http://localhost:1337/model.json')
+        });
+        var onNext = sinon.spy();
+
+        model.
+            get(['thing', 'prop']).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    json: {
+                        thing: {
+                            prop: null
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    afterEach(function() {
+        server.close();
+    });
+});

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,4 +1,5 @@
 describe('Integration', function() {
     require('./call.spec');
     require('./express.spec');
+    require('./get.spec');
 });

--- a/test/set/jsonGraphs/primitive.spec.js
+++ b/test/set/jsonGraphs/primitive.spec.js
@@ -11,6 +11,29 @@ var setJSONGraphs = require("../../../lib/set/setJSONGraphs");
 
 describe("a primitive value", function() {
 
+    it('should set a null object into an empty cache wrapping it in an atom.', function() {
+        var cache = {};
+        var version = 0;
+        var jsonGraphEnvelope = {
+            jsonGraph: {
+                a: {
+                    b: null
+                }
+            },
+            paths: [['a', 'b']]
+        };
+
+        setJSONGraphs(
+            getModel({cache: cache, version: version++}),
+            [jsonGraphEnvelope]);
+
+        expect(strip(cache)).to.deep.equal(strip({
+            a: {
+                b: $atom(null)
+            }
+        }));
+    });
+
     it("throws with a `null` key in a branch position", function() {
 
         var lru = new Object();


### PR DESCRIPTION
Made a small change to merge jsonGraph node so that if the message and the cache are equivalent and nullsy then there are two outcomes, not one.  Now the merge will consider a `null` value differently than an `undefined` value.