### PR TITLE
CI will build now build *all* dists, and commits (to master)

### DIFF
--- a/build/deploy-ghpages.sh
+++ b/build/deploy-ghpages.sh
@@ -26,6 +26,11 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   npm run doc
   npm run dist
 
+  git add dist/.
+  git commit -m "Travis build $TRAVIS_BUILD_NUMBER committed dist/"
+  # origin implied, whichever branch we're building implied
+  git push
+
   cp -R doc $FALCOR_DOCS_DIR
   cp -R dist $FALCOR_BUILD_DIR
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "test": "gulp test-coverage",
-    "dist": "gulp build",
+    "dist": "gulp all",
     "doc": "gulp doc",
     "perf": "gulp perf-run",
     "device": "devicePerfRunner",


### PR DESCRIPTION
So devs don't have to remember to build and commit dists with pull requests.