### PR TITLE
Updating package.json to reflect latest published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A JavaScript library for efficient data fetching.",
   "main": "./lib/index.js",
   "homepage": "https://github.com/Netflix/falcor",


### PR DESCRIPTION
0.1.13 was published off a branch (since master already had back-compat breaking changes).

The package.json was updated for the publish, on the branch, but needs to be reflected in master, until we publish the next bump.