### PR TITLE
Removed [fn].name override. Causes TypeError in strict mode

### DIFF
--- a/lib/errors/InvalidModelError.js
+++ b/lib/errors/InvalidModelError.js
@@ -17,7 +17,6 @@ function InvalidModelError(boundPath, shortedPath) {
 // instanceof will be an error, but stack will be correct because its defined in the constructor.
 InvalidModelError.prototype = new Error();
 InvalidModelError.prototype.name = NAME;
-InvalidModelError.name = NAME;
 InvalidModelError.message = MESSAGE;
 
 module.exports = InvalidModelError;

--- a/lib/errors/InvalidSourceError.js
+++ b/lib/errors/InvalidSourceError.js
@@ -16,7 +16,6 @@ function InvalidSourceError(error) {
 // in the constructor.
 InvalidSourceError.prototype = new Error();
 InvalidSourceError.prototype.name = NAME;
-InvalidSourceError.name = NAME;
 InvalidSourceError.is = function(e) {
     return e && e.name === NAME;
 };

--- a/lib/errors/MaxRetryExceededError.js
+++ b/lib/errors/MaxRetryExceededError.js
@@ -14,7 +14,6 @@ function MaxRetryExceededError() {
 // in the constructor.
 MaxRetryExceededError.prototype = new Error();
 MaxRetryExceededError.prototype.name = NAME;
-MaxRetryExceededError.name = NAME;
 MaxRetryExceededError.is = function(e) {
     return e && e.name === NAME;
 };


### PR DESCRIPTION
See: https://github.com/Netflix/falcor/issues/586#issuecomment-150840423

function.name is spec'd as read-only, and setting it, with "use strict" throws a TypeError in browser in which it's supported. In the browsers which support it, it's already "set", so we don't need to reset it.

IE seems to be the only outlier (haven't tested Edge): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Browser_compatibility

If we do need to set it for some reason, we probably need to try/catch or feature test before setting it, but not sure if we really need it set on the constructor function.