### PR TITLE
Updated build scripts to deploy off of current npm release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
 branches:
     only:
         - master
+        - 0.x
 
 # Run as a docker container
 sudo: false

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 **This release is a developer preview.** We are looking for community help to track down and fix bugs. We are also looking for help integrating with existing MVC frameworks, as well as ports to other platforms.
 
+* *master* currently reflects work in progress, and contains backward incompatible changes which will become the next major version bump.
+* *0.x* reflects the currently published npm version. Bug fixes specific to 0.x can be submitted against this branch.
+
 ## Important Note for Webpack Users
 
 If you're including falcor in your app, via npm and `require('falcor')`, and you're building a browser bundle for your app with Webpack, you'll need to add an alias entry for the 'rx' module in your webpack config, to avoid this RxJS bug: 'https://github.com/Reactive-Extensions/RxJS/issues/832'. You may already have such an entry, if you're using RxJS already. An example is below:

--- a/build/deploy-ghpages.sh
+++ b/build/deploy-ghpages.sh
@@ -39,10 +39,10 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   git commit -m "Travis build $TRAVIS_BUILD_NUMBER committed dist/"
   git push deployable $TRAVIS_BRANCH
 
-  if [ "$TRAVIS_BRANCH" == "$CURRENT_RELEASE"] then;
-  
+  if [ "$TRAVIS_BRANCH" == "$CURRENT_RELEASE" ]; then
+
     echo -e "Updating gh-pages...\n"
-  
+
     cp -R doc $FALCOR_DOCS_DIR
     cp -R dist $FALCOR_BUILD_DIR
 

--- a/build/deploy-ghpages.sh
+++ b/build/deploy-ghpages.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  echo -e "Starting to update gh-pages\n"
+  echo -e "Building and committing dist...\n"
 
   TEMP_DIR=$HOME/tmp
   FALCOR_DOCS_DIR=$TEMP_DIR/falcordocs
   FALCOR_BUILD_DIR=$TEMP_DIR/falcorbuild
   GH_PAGES_DIR=$TEMP_DIR/gh-pages
   DEPLOYABLE_REPO=https://${GH_TOKEN}@github.com/Netflix/falcor.git
+  CURRENT_RELEASE=0.x
 
   mkdir -p $TEMP_DIR
 
@@ -38,23 +39,28 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   git commit -m "Travis build $TRAVIS_BUILD_NUMBER committed dist/"
   git push deployable $TRAVIS_BRANCH
 
-  cp -R doc $FALCOR_DOCS_DIR
-  cp -R dist $FALCOR_BUILD_DIR
+  if [ "$TRAVIS_BRANCH" == "$CURRENT_RELEASE"] then;
+  
+    echo -e "Updating gh-pages...\n"
+  
+    cp -R doc $FALCOR_DOCS_DIR
+    cp -R dist $FALCOR_BUILD_DIR
 
-  # Change Working Directory to $HOME
-  cd $HOME
+    # Change Working Directory to $HOME
+    cd $HOME
 
-  git clone --quiet --branch=gh-pages $DEPLOYABLE_REPO $GH_PAGES_DIR > /dev/null
+    git clone --quiet --branch=gh-pages $DEPLOYABLE_REPO $GH_PAGES_DIR > /dev/null
 
-  # Change Working Directory to $HOME/gh-pages
-  cd $GH_PAGES_DIR
+    # Change Working Directory to $HOME/gh-pages
+    cd $GH_PAGES_DIR
 
-  rsync -r $FALCOR_DOCS_DIR/ doc/
-  rsync -r $FALCOR_BUILD_DIR/ build/
+    rsync -r $FALCOR_DOCS_DIR/ doc/
+    rsync -r $FALCOR_BUILD_DIR/ build/
 
-  git add .
-  git commit -m "Travis build $TRAVIS_BUILD_NUMBER pushed to gh-pages"
-  git push origin gh-pages
+    git add .
+    git commit -m "Travis build $TRAVIS_BUILD_NUMBER off $TRAVIS_BRANCH pushed to gh-pages"
+    git push origin gh-pages
 
-  echo -e "Deployed docs and build to gh-pages\n"
+    echo -e "Deployed docs and build to gh-pages\n"
+  fi
 fi


### PR DESCRIPTION
Currently the docs and Getting Started dist reflect the `0.x` branch, not `master`.

This update changes the build script to deploy gh-pages off of the 'currently released' branch (0.x for now), as opposed to `master`.