### PR TITLE
Fixes exceptions on call responses with only invalidations, and no returned paths

### DIFF
--- a/lib/support/array-flat-map.js
+++ b/lib/support/array-flat-map.js
@@ -2,7 +2,7 @@ module.exports = function arrayFlatMap(array, selector) {
     var index = -1;
     var i = -1;
     var n = array.length;
-    var array2 = new Array(n);
+    var array2 = [];
     while (++i < n) {
         var array3 = selector(array[i], i, array);
         var j = -1;

--- a/test/integration/call.spec.js
+++ b/test/integration/call.spec.js
@@ -110,16 +110,12 @@ describe('call', function() {
         var args = [falcor.Model.ref('titlesById[1]')];
 
         var onNext = sinon.spy();
-        var onError = sinon.spy();
 
         model.
             call("genreList[0].titles.push", args).
-            doAction(onNext, onError).
-            subscribe(onNext, onError, function() {
-
-                expect(onError.callCount).to.equal(0);
+            doAction(onNext, noOp, noOp).
+            subscribe(noOp, done, function() {
                 expect(onNext.callCount).to.equal(0);
-
                 done();
             });
     });

--- a/test/integration/call.spec.js
+++ b/test/integration/call.spec.js
@@ -86,5 +86,42 @@ describe('call', function() {
             }).
             subscribe(noOp, done, done);
     });
+
+    it('Response with invalidations and no paths should not explode.', function(done) {
+        var router = new R([{
+            route: 'genreList[{integers:titles}].titles.push',
+            call: function(callPath, args) {
+
+                var invalidatedPath = callPath.slice(0, callPath.length-1);
+                // [genreList, [0], titles, length]
+                invalidatedPath.push('length');
+
+                return {
+                    path: invalidatedPath,
+                    invalidated: true
+                };
+            }
+        }]);
+
+        var model = new falcor.Model({
+            source: router
+        });
+
+        var args = [falcor.Model.ref('titlesById[1]')];
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy();
+
+        model.
+            call("genreList[0].titles.push", args).
+            doAction(onNext, onError).
+            subscribe(onNext, onError, function() {
+
+                expect(onError.callCount).to.equal(0);
+                expect(onNext.callCount).to.equal(0);
+
+                done();
+            });
+    });
 });
 


### PR DESCRIPTION
We ended up trying to make a get with a requestedPath = [undefined], due to a bug in arrayFlatMap which wasn't accounting for the selector filtering out values, by initializing the flatMapped array to a fixed size.

See #589
See #477#issuecomment-152336762

@michaelbpaulson @jhusain 