### PR TITLE
0.x wip

### DIFF
--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -150,6 +150,7 @@ module.exports = function mergeJSONGraphNode(
 
         if (mType === $error && isFunction(errorSelector)) {
             message = errorSelector(reconstructPath(requestedPath, key), message);
+            mType = message.$type || mType;
         }
 
         if (mType && node === message) {

--- a/lib/support/mergeValueOrInsertBranch.js
+++ b/lib/support/mergeValueOrInsertBranch.js
@@ -49,11 +49,12 @@ module.exports = function mergeValueOrInsertBranch(
         }
         if (isDistinct) {
 
-            message = wrapNode(message, mType, mType ? message.value : message);
-
             if (mType === $error && isFunction(errorSelector)) {
                 message = errorSelector(reconstructPath(requestedPath, key), message);
+                mType = message.$type || mType;
             }
+
+            message = wrapNode(message, mType, mType ? message.value : message);
 
             var sizeOffset = getSize(node) - getSize(message);
 


### PR DESCRIPTION
@sdesai there is an interesting thing in here.  I noticed that `wrapNode` is called in different order so if the `errorSelector` returned anything but the value it would remove the whole value from the cache (size becomes 0), unless the `errorSelector` also provides the size.  By moving `wrapNode`, all is well in the universe.