### PR TITLE
The core was not considering already materialized atoms correctly

### DIFF
--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -69,7 +69,7 @@ module.exports = function onValueType(
         }
 
         if (!requiresMaterializedToReport ||
-            requiresMaterializedToReport && isMaterialized(model)) {
+            requiresMaterializedToReport && model._materialized) {
 
             onValue(model, node, seed, depth, outerResults, requestedPath,
                     optimizedPath, optimizedLength, isJSONG, fromReference);

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -2,6 +2,7 @@ var getCoreRunner = require('./../getCoreRunner');
 var cacheGenerator = require('./../CacheGenerator');
 var jsonGraph = require('falcor-json-graph');
 var atom = jsonGraph.atom;
+var ref = jsonGraph.ref;
 var _ = require('lodash');
 
 describe('Values', function() {
@@ -38,6 +39,39 @@ describe('Values', function() {
                 }
             },
             cache: cacheGenerator(0, 1)
+        });
+    });
+    it('should get a value of type atom when in materialized mode.', function() {
+        getCoreRunner({
+            input: [['videos', {to:1}, 'title']],
+            materialize: true,
+            output: {
+                json: {
+                    videos: {
+                        0: {
+                            title: {$type: 'atom'}
+                        },
+                        1: {
+                            title: {$type: 'atom'}
+                        }
+                    }
+                }
+            },
+            cache: {
+                jsonGraph: {
+                    videos: {
+                        0: {
+                            title: {$type: 'atom'}
+                        },
+                        1: {
+                            title: {$type: 'atom'}
+                        }
+                    }
+                },
+                paths: [
+                    ['videos', {to: 1}, 'title']
+                ]
+            }
         });
     });
     it('should get a value through references with complex pathSet.', function() {


### PR DESCRIPTION
@sdesai There is a get rule that requires if a path is missing `get` will only materialize it if there is a `_source` and `_materialized` is true, but if there already is a path that has been materialized, to report it only requires `_materialized` to be true.  I was using the former logic to generate the output, thus incorrectly generating empty output for most cases.