### PR TITLE
getCache was still getting serializable issues

### DIFF
--- a/lib/get/getCache.js
+++ b/lib/get/getCache.js
@@ -1,6 +1,6 @@
 var $modelCreated = require("./../internal/model-created");
 var clone = require("./util/clone");
-var prefix = require("./../internal/prefix");
+var isInternalKey = require("./../support/isInternalKey");
 
 /**
  * decends and copies the cache.
@@ -18,7 +18,7 @@ function _copyCache(node, out, fromKey) {
     Object.
         keys(node).
         filter(function(k) {
-            return k[0] !== prefix && k !== "$size";
+            return !isInternalKey(k);
         }).
         forEach(function(key) {
             var cacheNext = node[key];

--- a/lib/support/isInternalKey.js
+++ b/lib/support/isInternalKey.js
@@ -1,0 +1,22 @@
+var __parent = require("./../internal/parent");
+var __key = require("./../internal/key");
+var __version = require("./../internal/version");
+var __prev = require("./../internal/prev");
+var __next = require("./../internal/next");
+
+/**
+ * If the key passed in is an internal key.  We will use a simple checking to
+ * prevent infinite recursion on some machines.
+ *
+ * @param {String} x -
+ * @private
+ * @returns {Boolean}
+ */
+module.exports = function isInternalKey(x) {
+    return x === __parent ||
+        x === __key ||
+        x === __version ||
+        x === __prev ||
+        x === __next ||
+        x === "$size";
+};


### PR DESCRIPTION
So instead of doing 
```
x[0] !== prefix && x !== '$size';
```
we switched it up with a more verbose check.

```
module.exports = function isInternalKey(x) {
    return x === __parent ||
        x === __key ||
        x === __version ||
        x === __prev ||
        x === __next ||
        x === "$size";
};
```
#601 