### PR TITLE
Fixed deref completing, without onNext'ing a bound model, if the preload paths fail

### DIFF
--- a/lib/deref/index.js
+++ b/lib/deref/index.js
@@ -38,12 +38,15 @@ module.exports = function deref(boundPathArg) {
     flatMap(function(boundModel) {
         if (Boolean(boundModel)) {
             if (pathsCount > 0) {
+
                 return boundModel.get.
                     apply(boundModel, paths).
                     map(function() {
                         return boundModel;
                     }).
-                    catch(Rx.Observable.empty());
+                    catch(Rx.Observable.of(boundModel)).
+                    take(1);
+
             }
             return Rx.Observable.return(boundModel);
         } else if (pathsCount > 0) {

--- a/test/falcor/bind/bind-cases.spec.js
+++ b/test/falcor/bind/bind-cases.spec.js
@@ -166,6 +166,56 @@ describe('Deref', function() {
 
         expect(out.value).to.equals(undefined);
     });
+
+    it('should deliver successfully bound model if preload path errors', function(done) {
+
+        var modelCache = getCache();
+        var model = new Model({ cache: modelCache });
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy(function() {
+            assert.fail(0, 1, "Did not expect error handler to be invoked");
+        });
+
+        model.
+            deref(['lolomo', 0], [1, 'item', 'info']).
+            doAction(onNext, onError, function() {
+                var boundModel = onNext.getCall(0).args[0];
+
+                expect(onNext.callCount).to.equal(1);
+                expect(boundModel).to.not.equal(model);
+                expect(boundModel._path).to.deep.equal(
+                    ['lists', 'c595efe8-4de0-4226-8d4a-ebe89d236e2f_fcce4c47-7b36-456b-89ac-bde430a24ca8']
+                );
+
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should deliver successfully bound model if one preload path succeeds, and one preload path errors', function(done) {
+
+        var modelCache = getCache();
+        var model = new Model({ cache: modelCache });
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy(function() {
+            assert.fail(0, 1, "Did not expect error handler to be invoked");
+        });
+
+        model.
+            deref(['lolomo', 0], [[0,1], 'item', 'info']).
+            doAction(onNext, onError, function() {
+                var boundModel = onNext.getCall(0).args[0];
+
+                expect(onNext.callCount).to.equal(1);
+                expect(boundModel).to.not.equal(model);
+                expect(boundModel._path).to.deep.equal(
+                    ['lists', 'c595efe8-4de0-4226-8d4a-ebe89d236e2f_fcce4c47-7b36-456b-89ac-bde430a24ca8']
+                );
+
+            }).
+            subscribe(noOp, done, done);
+    });
 });
 
 function getCache() {
@@ -213,9 +263,23 @@ function getCache() {
                         "$type": "atom",
                     }
                 },
+                "1":{
+                    "item": {
+                        "$type": "ref",
+                        "value": ["videos", "err"],
+                    }
+                }
             },
         },
         "videos": {
+            "err": {
+                "info": {
+                    "$type": "error",
+                    "value": {
+                        "message": "errormsg"
+                    }
+                }
+            },
             "80041601": {
                 "info": {
                     "value": {


### PR DESCRIPTION
We were swallowing errors on preload paths, and not onNexting a successfully bound model as a result.

This PR aims to fix that (For the current 0.x deref. It's N/A for the new 1.x/master deref).

@michaelbpaulson - Could you take a quick look at this, including the unit tests (to make sure I'm testing the correct 'as designed' expectation).