### PR TITLE
Fix getCache() internal key filtering

### DIFF
--- a/lib/get/getCache.js
+++ b/lib/get/getCache.js
@@ -1,5 +1,4 @@
 var $modelCreated = require("./../internal/model-created");
-var clone = require("./util/clone");
 var isInternalKey = require("./../support/isInternalKey");
 
 /**
@@ -11,6 +10,25 @@ module.exports = function getCache(cache) {
 
     return out;
 };
+
+function cloneBoxedValue(boxedValue) {
+    var clonedValue = {};
+
+    var keys = Object.keys(boxedValue);
+    var key;
+    var i;
+    var l;
+
+    for (i = 0, l = keys.length; i < l; i++) {
+        key = keys[i];
+
+        if (!isInternalKey(key)) {
+            clonedValue[key] = boxedValue[key];
+        }
+    }
+
+    return clonedValue;
+}
 
 function _copyCache(node, out, fromKey) {
     // copy and return
@@ -40,7 +58,7 @@ function _copyCache(node, out, fromKey) {
                 var isUserCreatedcacheNext = !node[$modelCreated];
                 var value;
                 if (isObject || isUserCreatedcacheNext) {
-                    value = clone(cacheNext);
+                    value = cloneBoxedValue(cacheNext);
                 } else {
                     value = cacheNext.value;
                 }

--- a/lib/support/isInternalKey.js
+++ b/lib/support/isInternalKey.js
@@ -1,22 +1,12 @@
-var __parent = require("./../internal/parent");
-var __key = require("./../internal/key");
-var __version = require("./../internal/version");
-var __prev = require("./../internal/prev");
-var __next = require("./../internal/next");
+var prefix = require("./../internal/prefix");
 
 /**
- * If the key passed in is an internal key.  We will use a simple checking to
- * prevent infinite recursion on some machines.
+ * Determined if the key passed in is an internal key.
  *
- * @param {String} x -
+ * @param {String} x The key
  * @private
  * @returns {Boolean}
  */
 module.exports = function isInternalKey(x) {
-    return x === __parent ||
-        x === __key ||
-        x === __version ||
-        x === __prev ||
-        x === __next ||
-        x === "$size";
+    return (x === "$size") || (x && (x.charAt(0) === prefix));
 };

--- a/test/falcor/set/set.setCache.spec.js
+++ b/test/falcor/set/set.setCache.spec.js
@@ -84,25 +84,59 @@ describe('Cache Only', function() {
     });
     it("should be fine when you hydrate from an existing cache", function(done) {
         var model = new Model({
-            cache: { a: {
-                b: $ref("a"),
-                c: "foo" } },
+            cache: {
+                a: {
+                    b: $ref("a"),
+                    c: "foo"
+                }
+            },
             source: new LocalDataSource({
-                a: { b: $ref("d") },
-                d: { c: "foo" }
+                a: {
+                    b: $ref("d")
+                },
+                d: {
+                    c: "foo"
+                }
             })});
+
         var cache = model.getCache();
         model.setCache({});
+
         model.get("a.b.c").subscribe(function(x) {
             expect(x).to.deep.equal({
                 json: { a: { b: { c: "foo" } }}
             });
         });
+
         model.setCache(cache);
         model.get("a.b.c").subscribe(function(x) {
             expect(x).to.deep.equal({
                 json: { a: { b: { c: "foo" } }}
             });
         }, done, done);
+    });
+    it("should re-establish atoms and references when you hydrate from an existing cache into a completely new model instance", function(done) {
+        var modelOrig = new Model({
+            cache: {
+                a: {
+                    b: $ref("d")
+                },
+                d: {
+                    c: "foo"
+                }
+            }
+        });
+
+        var cache = modelOrig.getCache();
+        var modelNew = new Model();
+
+        modelNew.setCache(cache);
+        modelNew.get("a.b.c").subscribe(function(x) {
+
+            expect(x).to.deep.equal({
+                json: { a: { b: { c: "foo" } }}
+            });
+        }, done, done);
+
     });
 });

--- a/test/get-core/get.cache.spec.js
+++ b/test/get-core/get.cache.spec.js
@@ -1,9 +1,20 @@
 var cacheGenerator = require('./../CacheGenerator');
 var falcor = require("./../../lib/");
+var isInternalKey = require("./../../lib/support/isInternalKey");
 var clean = require('./../cleanData').clean;
 var Model = falcor.Model;
 var expect = require('chai').expect;
 var atom = Model.atom;
+
+function deepExpectations(o, expectExpression) {
+    for (var k in o) {
+        expectExpression(k);
+
+        if (typeof o[k] === 'object') {
+            deepExpectations(o[k], expectExpression);
+        }
+    }
+}
 
 describe('getCache', function() {
 
@@ -19,6 +30,20 @@ describe('getCache', function() {
         var cache = model.getCache(['lolomo', 0, 3, 'item', 'title']);
         clean(cache);
         expect(cache).to.deep.equals(cacheGenerator(3, 1));
+    });
+
+    it("serialized cache should not contain internal keys (including $size, on boxedValues)", function(done) {
+        var model = new Model({ cache: cacheGenerator(0, 1) });
+
+        model.get(['lolomo', 0, 0, 'item', 'title']).subscribe(function() {}, done, function() {
+            var cache = model.getCache();
+
+            deepExpectations(cache, function(key) {
+                expect(isInternalKey(key)).to.equal(false);
+            });
+
+            done();
+        });
     });
 
     it('should serialize a cache with undefined values.', function() {


### PR DESCRIPTION
I didn't get a chance to get the context around this PR from Michael in person before he stepped out on vacation: https://github.com/Netflix/falcor/pull/640/ but it seems to have regressed `model.getCache()` behavior, by allowing some internal keys to remain in the results of `model.getCache()` (e.g. refN, ref-index, etc). It seems to be a pretty conscious change, so not sure if it was intentional.

However, in the absence of this context, it seems like the desired behavior is to strip *ALL* internal keys from the cache, when returning a copy through `getCache()`.

This PR aims to fix the above regression, and also fix what seems to be a gap in the original implementation, where `$size` would still be left in the results of `getCache()` at the leaf/sentinel nodes, when cloning boxed values. I don't think this was intentional.

Unit tests added, to make sure:

1. Stripping `refN`, `ref-index` doesn't result in references breaking when the copy of the cache is used to re-hydrate a new model
2. Make sure no internal keys are left in the cache-copy returned by `getCache()`

@jhusain @michaelbpaulson @trxcllnt - eyes appreciated, especially since I'm making assumptions about the original design intention.