### PR TITLE
feature(onChange): Call ModelRoot's `onChange` handler in the context of the original top-level Model.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -73,7 +73,7 @@ Model.pathValue = jsong.pathValue;
 function Model(o) {
 
     var options = o || {};
-    this._root = options._root || new ModelRoot(options);
+    this._root = options._root || new ModelRoot(options, this);
     this._path = options.path || options._path || [];
     this._scheduler = options.scheduler || options._scheduler || new ImmediateScheduler();
     this._source = options.source || options._source;

--- a/lib/ModelRoot.js
+++ b/lib/ModelRoot.js
@@ -2,7 +2,7 @@ var isFunction = require("./support/isFunction");
 var hasOwn = require("./support/hasOwn");
 var ImmediateScheduler = require("./schedulers/ImmediateScheduler");
 
-function ModelRoot(o) {
+function ModelRoot(o, topLevelModel) {
 
     var options = o || {};
 
@@ -11,6 +11,7 @@ function ModelRoot(o) {
     this.unsafeMode = options.unsafeMode || false;
     this.collectionScheduler = options.collectionScheduler || new ImmediateScheduler();
     this.cache = {};
+    this.topLevelModel = topLevelModel;
 
     if (isFunction(options.comparator)) {
         this.comparator = options.comparator;

--- a/lib/invalidate/invalidatePathMaps.js
+++ b/lib/invalidate/invalidatePathMaps.js
@@ -61,7 +61,7 @@ module.exports = function invalidatePathMaps(model, pathMapEnvelopes) {
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
-        rootChangeHandler();
+        rootChangeHandler.call(modelRoot.topLevelModel);
     }
 };
 

--- a/lib/invalidate/invalidatePathSets.js
+++ b/lib/invalidate/invalidatePathSets.js
@@ -57,7 +57,7 @@ module.exports = function invalidatePathSets(model, paths) {
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
-        rootChangeHandler();
+        rootChangeHandler.call(modelRoot.topLevelModel);
     }
 };
 

--- a/lib/set/setJSONGraphs.js
+++ b/lib/set/setJSONGraphs.js
@@ -69,7 +69,7 @@ module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelec
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
-        rootChangeHandler();
+        rootChangeHandler.call(modelRoot.topLevelModel);
     }
 
     return [requestedPaths, optimizedPaths];

--- a/lib/set/setPathMaps.js
+++ b/lib/set/setPathMaps.js
@@ -67,7 +67,7 @@ module.exports = function setPathMaps(model, pathMapEnvelopes, x, errorSelector,
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
-        rootChangeHandler();
+        rootChangeHandler.call(modelRoot.topLevelModel);
     }
 
     return [requestedPaths, optimizedPaths];

--- a/lib/set/setPathValues.js
+++ b/lib/set/setPathValues.js
@@ -66,7 +66,7 @@ module.exports = function setPathValues(model, pathValues, x, errorSelector, com
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
-        rootChangeHandler();
+        rootChangeHandler.call(modelRoot.topLevelModel);
     }
 
     return [requestedPaths, optimizedPaths];

--- a/test/falcor/invalidate/invalidate.change-handler.spec.js
+++ b/test/falcor/invalidate/invalidate.change-handler.spec.js
@@ -17,4 +17,41 @@ describe("root onChange handler", function () {
 
         expect(changed).to.be.ok;
     });
+    xit("is called when we invalidate a path via JSON", function() {
+
+        var changed = false;
+        var model = new Model({
+            cache: { a: { b: { c: "foo" } } },
+            onChange: function () {
+                changed = true;
+            }
+        });
+
+        model.invalidate({ json: { a: { b: { c: true }}}});
+
+        expect(changed).to.be.ok;
+    });
+    it("is called in the context of the root Model", function() {
+
+        var firstCall = false;
+        var onChangeContext = null;
+        var topLevelModel = new Model({
+            cache: { a: { b: { c: "foo" } } },
+            onChange: function() {
+                // This check ensures we don't run our expectation when the
+                // onChange handler is run synchronously as a result of
+                // seeding the Model with a cache.
+                if (!firstCall) {
+                    firstCall = true;
+                    return;
+                }
+                onChangeContext = this;
+                expect(this).to.equal(topLevelModel);
+            }
+        });
+
+        topLevelModel.invalidate(["a", "b", "c"]);
+
+        expect(onChangeContext).to.equal(topLevelModel);
+    });
 });

--- a/test/falcor/set/set.change-handler.spec.js
+++ b/test/falcor/set/set.change-handler.spec.js
@@ -27,4 +27,30 @@ describe("root onChange handler", function () {
         expect(changed, "onChange wasn't called.").to.be.ok;
         expect(calledBeforeEnsure, "onChange wasn't called before the subscription was disposed.").to.be.ok;
     });
+    it("is called in the context of the root Model", function() {
+        var topLevelModel = new Model({
+            onChange: function() {
+                expect(this).to.equal(topLevelModel);
+            }
+        });
+        toObservable(topLevelModel.set({
+            path: ["a", "b", "c"],
+            value: "foo"
+        }))
+        .subscribe();
+    });
+    it("is called in the context of the root Model synchronously when initialized with a cache", function() {
+        var onChangeContext;
+        var onChangeCalledSynchronously = false;
+        var topLevelModel = new Model({
+            onChange: function() {
+                onChangeContext = this;
+                expect(topLevelModel).to.not.be.ok;
+                onChangeCalledSynchronously = true;
+            },
+            cache: { a: { b: { c: "foo" } } }
+        });
+        expect(onChangeContext).to.equal(topLevelModel)
+        expect(onChangeCalledSynchronously).to.be.true;
+    });
 });


### PR DESCRIPTION
This change ensures that the `onChange` handler has access to the top-level Model instance on each invocation, even if the `onChange` handler is called synchronously as a result of seeding the top-level Model with an initial cache.

This change fixes an ergonomic issue [already encountered](https://github.com/Netflix/falcor/issues/626#issuecomment-159350507) by the community. While it's possible to work around this with external state and flags, this solution is not as obvious to members of the community with less knowledge of the Falcor internals than me. This is about developer friendliness more than anything else.

cc: @michaelbpaulson @sdesai @jhusain 