### PR TITLE
feat(performance): Removal of dynamic keys for get/lru

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -360,12 +360,18 @@ Model.prototype.setCache = function modelSetCache(cacheOrJSONGraphEnvelope) {
         if (typeof cache !== "undefined") {
             collectLru(modelRoot, modelRoot.expired, getSize(cache), 0);
         }
+        var out;
         if (isJSONGraphEnvelope(cacheOrJSONGraphEnvelope)) {
-            setJSONGraphs(this, [cacheOrJSONGraphEnvelope]);
+            out = setJSONGraphs(this, [cacheOrJSONGraphEnvelope])[0];
         } else if (isJSONEnvelope(cacheOrJSONGraphEnvelope)) {
-            setCache(this, [cacheOrJSONGraphEnvelope]);
+            out = setCache(this, [cacheOrJSONGraphEnvelope])[0];
         } else if (isObject(cacheOrJSONGraphEnvelope)) {
-            setCache(this, [{ json: cacheOrJSONGraphEnvelope }]);
+            out = setCache(this, [{ json: cacheOrJSONGraphEnvelope }])[0];
+        }
+
+        // performs promotion without producing output.
+        if (out) {
+            get.getWithPathsAsPathMap(this, out, []);
         }
         this._path = boundPath;
     } else if (typeof cache === "undefined") {

--- a/lib/get/followReference.js
+++ b/lib/get/followReference.js
@@ -3,7 +3,6 @@ var createHardlink = hardLink.create;
 var onValue = require("./../get/onValue");
 var isExpired = require("./../get/util/isExpired");
 var $ref = require("./../types/ref");
-var __context = require("./../internal/context");
 var promote = require("./../lru/promote");
 
 /* eslint-disable no-constant-condition */
@@ -17,9 +16,9 @@ function followReference(model, root, nodeArg, referenceContainerArg,
     var k, next;
 
     while (true) {
-        if (depth === 0 && referenceContainer[__context]) {
+        if (depth === 0 && referenceContainer.ツcontext) {
             depth = reference.length;
-            next = referenceContainer[__context];
+            next = referenceContainer.ツcontext;
         } else {
             k = reference[depth++];
             next = node[k];
@@ -47,7 +46,7 @@ function followReference(model, root, nodeArg, referenceContainerArg,
                     break;
                 }
 
-                if (!referenceContainer[__context]) {
+                if (!referenceContainer.ツcontext) {
                     createHardlink(referenceContainer, next);
                 }
 

--- a/lib/get/getCache.js
+++ b/lib/get/getCache.js
@@ -42,7 +42,8 @@ function _copyCache(node, out, fromKey) {
             // 2: A $type-value node.
             // 3: undefined
             // We will strip out 3
-            return !isInternalKey(k) && node[k];
+            return (!isInternalKey(k) || k === $modelCreated) &&
+                node[k] !== undefined;
         }).
         forEach(function(key) {
             var cacheNext = node[key];
@@ -55,7 +56,7 @@ function _copyCache(node, out, fromKey) {
             // Paste the node into the out cache.
             if (cacheNext.$type) {
                 var isObject = cacheNext.value && typeof cacheNext.value === "object";
-                var isUserCreatedcacheNext = !node[$modelCreated];
+                var isUserCreatedcacheNext = !cacheNext[$modelCreated];
                 var value;
                 if (isObject || isUserCreatedcacheNext) {
                     value = cloneBoxedValue(cacheNext);

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -8,6 +8,11 @@ var $modelCreated = require("./../internal/model-created");
 module.exports = function onValue(model, node, seed, depth, outerResults,
                                   branchInfo, requestedPath, optimizedPath,
                                   optimizedLength, isJSONG) {
+    // Promote first.  Even if no output is produced we should still promote.
+    if (node) {
+        promote(model._root, node);
+    }
+
     // Preload
     if (!seed) {
         return;
@@ -15,10 +20,6 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
 
     var i, len, k, key, curr, prev = null, prevK;
     var materialized = false, valueNode;
-
-    if (node) {
-        promote(model._root, node);
-    }
 
     if (!node || node.value === undefined) {
         materialized = model._materialized;

--- a/lib/get/util/clone.js
+++ b/lib/get/util/clone.js
@@ -1,6 +1,7 @@
 // Copies the node
 var prefix = require("./../../internal/prefix");
-var $absolutePath = require("./../../internal/absolutePath");
+var unicodePrefix = require("./../../internal/unicodePrefix");
+var $modelCreated = require("./../../internal/model-created");
 
 module.exports = function clone(node) {
     var outValue, i, len;
@@ -8,7 +9,8 @@ module.exports = function clone(node) {
     outValue = {};
     for (i = 0, len = keys.length; i < len; i++) {
         var k = keys[i];
-        if (k[0] === prefix || k === $absolutePath) {
+        var k0 = k.charAt(0);
+        if (k0 === prefix || k0 === unicodePrefix || k === $modelCreated) {
             continue;
         }
         outValue[k] = node[k];

--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -6,7 +6,6 @@ var iterateKeySet = require("falcor-path-utils").iterateKeySet;
 var $ref = require("./../types/ref");
 var NullInPathError = require("./../errors/NullInPathError");
 var promote = require("./../lru/promote");
-var $absolutePath = require("./../internal/absolutePath");
 
 module.exports = function walkPath(model, root, curr, path, depth, seed,
                                    outerResults, branchInfo, requestedPath,
@@ -120,9 +119,9 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // There was a reference container.
                 if (referenceContainer && allowFromWhenceYouCame) {
                     obj = {
-                        $__path: next[$absolutePath],
+                        $__path: next.ツabsolutePath,
                         $__refPath: referenceContainer.value,
-                        $__toReference: referenceContainer[$absolutePath]
+                        $__toReference: referenceContainer.ツabsolutePath
                     };
                 }
 
@@ -131,7 +130,7 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // contain references.
                 else {
                     obj = {
-                        $__path: next.$absolutePath
+                        $__path: next.ツabsolutePath
                     };
                 }
 

--- a/lib/internal/absolutePath.js
+++ b/lib/internal/absolutePath.js
@@ -1,1 +1,1 @@
-module.exports = "$absolutePath";
+module.exports = require("./unicodePrefix") + "absolutePath";

--- a/lib/internal/context.js
+++ b/lib/internal/context.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "context";
+module.exports = require("./unicodePrefix") + "context";

--- a/lib/internal/head.js
+++ b/lib/internal/head.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "head";
+module.exports = require("./unicodePrefix") + "head";

--- a/lib/internal/next.js
+++ b/lib/internal/next.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "next";
+module.exports = require("./unicodePrefix") + "next";

--- a/lib/internal/prev.js
+++ b/lib/internal/prev.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "prev";
+module.exports = require("./unicodePrefix") + "prev";

--- a/lib/internal/ref-index.js
+++ b/lib/internal/ref-index.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "ref-index";
+module.exports = require("./prefix") + "ref-index";

--- a/lib/internal/tail.js
+++ b/lib/internal/tail.js
@@ -1,1 +1,1 @@
-module.exports = require("./../internal/prefix") + "tail";
+module.exports = require("./unicodePrefix") + "tail";

--- a/lib/internal/unicodePrefix.js
+++ b/lib/internal/unicodePrefix.js
@@ -1,0 +1,2 @@
+module.exports = "ツ";
+

--- a/lib/lru/collect.js
+++ b/lib/lru/collect.js
@@ -1,11 +1,5 @@
 var __key = require("./../internal/key");
 var __parent = require("./../internal/parent");
-
-var __head = require("./../internal/head");
-var __tail = require("./../internal/tail");
-var __next = require("./../internal/next");
-var __prev = require("./../internal/prev");
-
 var removeNode = require("./../support/removeNode");
 var updateNodeAncestors = require("./../support/updateNodeAncestors");
 
@@ -36,10 +30,10 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
     }
 
     if (total >= max) {
-        var prev = lru[__tail];
+        var prev = lru.ツtail;
         node = prev;
         while ((total >= targetSize) && node) {
-            prev = prev[__prev];
+            prev = prev.ツprev;
             size = node.$size || 0;
             total -= size;
             if (shouldUpdate === true) {
@@ -48,11 +42,11 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
             node = prev;
         }
 
-        lru[__tail] = lru[__prev] = node;
+        lru.ツtail = lru.ツprev = node;
         if (node == null) {
-            lru[__head] = lru[__next] = void 0;
+            lru.ツhead = lru.ツnext = undefined;
         } else {
-            node[__next] = void 0;
+            node.ツnext = undefined;
         }
     }
 };

--- a/lib/lru/promote.js
+++ b/lib/lru/promote.js
@@ -1,7 +1,3 @@
-var __head = require("./../internal/head");
-var __tail = require("./../internal/tail");
-var __next = require("./../internal/next");
-var __prev = require("./../internal/prev");
 var EXPIRES_NEVER = require("./../values/expires-never");
 
 // [H] -> Next -> ... -> [T]
@@ -12,11 +8,11 @@ module.exports = function lruPromote(root, object) {
         return;
     }
 
-    var head = root[__head];
+    var head = root.ツhead;
 
     // Nothing is in the cache.
     if (!head) {
-        root[__head] = root[__tail] = object;
+        root.ツhead = root.ツtail = object;
         return;
     }
 
@@ -26,23 +22,23 @@ module.exports = function lruPromote(root, object) {
 
     // The item always exist in the cache since to get anything in the
     // cache it first must go through set.
-    var prev = object[__prev];
-    var next = object[__next];
+    var prev = object.ツprev;
+    var next = object.ツnext;
     if (next) {
-        next[__prev] = prev;
+        next.ツprev = prev;
     }
     if (prev) {
-        prev[__next] = next;
+        prev.ツnext = next;
     }
-    object[__prev] = undefined;
+    object.ツprev = undefined;
 
     // Insert into head position
-    root[__head] = object;
-    object[__next] = head;
-    head[__prev] = object;
+    root.ツhead = object;
+    object.ツnext = head;
+    head.ツprev = object;
 
     // If the item we promoted was the tail, then set prev to tail.
-    if (object === root[__tail]) {
-        root[__tail] = prev;
+    if (object === root.ツtail) {
+        root.ツtail = prev;
     }
 };

--- a/lib/lru/splice.js
+++ b/lib/lru/splice.js
@@ -1,25 +1,20 @@
-var __head = require("./../internal/head");
-var __tail = require("./../internal/tail");
-var __next = require("./../internal/next");
-var __prev = require("./../internal/prev");
-
 module.exports = function lruSplice(root, object) {
 
     // Its in the cache.  Splice out.
-    var prev = object[__prev];
-    var next = object[__next];
+    var prev = object.ツprev;
+    var next = object.ツnext;
     if (next) {
-        next[__prev] = prev;
+        next.ツprev = prev;
     }
     if (prev) {
-        prev[__next] = next;
+        prev.ツnext = next;
     }
-    object[__prev] = object[__next] = undefined;
+    object.ツprev = object.ツnext = undefined;
 
-    if (object === root[__head]) {
-        root[__head] = next;
+    if (object === root.ツhead) {
+        root.ツhead = next;
     }
-    if (object === root[__tail]) {
-        root[__tail] = prev;
+    if (object === root.ツtail) {
+        root.ツtail = prev;
     }
 };

--- a/lib/set/setJSONGraphs.js
+++ b/lib/set/setJSONGraphs.js
@@ -7,7 +7,6 @@ var __refsLength = require("./../internal/refs-length");
 
 var $ref = require("./../types/ref");
 
-var promote = require("./../lru/promote");
 var isExpired = require("./../support/isAlreadyExpired");
 var isFunction = require("./../support/isFunction");
 var isPrimitive = require("./../support/isPrimitive");
@@ -112,7 +111,6 @@ function setJSONGraphPathSet(
                     version, expired, lru, comparator, errorSelector
                 );
             } else {
-                promote(lru, nextNode);
                 requestedPaths.push(requestedPath.slice(0, requestedPath.index + 1));
                 optimizedPaths.push(optimizedPath.slice(0, optimizedPath.index));
             }
@@ -139,8 +137,6 @@ function setReference(
         expireNode(node, expired, lru);
         return [undefined, root, message, messageRoot];
     }
-
-    promote(lru, node);
 
     var index = 0;
     var container = node;

--- a/lib/set/setPathMaps.js
+++ b/lib/set/setPathMaps.js
@@ -12,7 +12,6 @@ var $ref = require("./../types/ref");
 var getBoundValue = require("./../get/getBoundValue");
 
 var isArray = Array.isArray;
-var promote = require("./../lru/promote");
 var hasOwn = require("./../support/hasOwn");
 var isObject = require("./../support/isObject");
 var isExpired = require("./../support/isExpired");
@@ -115,7 +114,6 @@ function setPathMap(
                         version, expired, lru, comparator, errorSelector
                     );
                 } else {
-                    promote(lru, nextNode);
                     requestedPaths.push(requestedPath.slice(0, requestedPath.index + 1));
                     optimizedPaths.push(optimizedPath.slice(0, optimizedPath.index));
                 }
@@ -142,8 +140,6 @@ function setReference(
         expireNode(node, expired, lru);
         return [undefined, root];
     }
-
-    promote(lru, node);
 
     var container = node;
     var parent = root;

--- a/lib/set/setPathValues.js
+++ b/lib/set/setPathValues.js
@@ -10,7 +10,6 @@ var $ref = require("./../types/ref");
 
 var getBoundValue = require("./../get/getBoundValue");
 
-var promote = require("./../lru/promote");
 var isExpired = require("./../support/isExpired");
 var isFunction = require("./../support/isFunction");
 var isPrimitive = require("./../support/isPrimitive");
@@ -107,7 +106,6 @@ function setPathSet(
                     version, expired, lru, comparator, errorSelector
                 );
             } else {
-                promote(lru, nextNode);
                 requestedPaths.push(requestedPath.slice(0, requestedPath.index + 1));
                 optimizedPaths.push(optimizedPath.slice(0, optimizedPath.index));
             }
@@ -134,8 +132,6 @@ function setReference(
         expireNode(node, expired, lru);
         return [undefined, root];
     }
-
-    promote(lru, node);
 
     var container = node;
     var parent = root;

--- a/lib/support/clone.js
+++ b/lib/support/clone.js
@@ -1,7 +1,9 @@
 var prefix = require("./../internal/prefix");
+var unicodePrefix = require("./../internal/unicodePrefix");
 var hasOwn = require("./../support/hasOwn");
 var isArray = Array.isArray;
 var isObject = require("./../support/isObject");
+var $modelCreated = require("./../internal/model-created");
 
 module.exports = function clone(value) {
     var dest = value;
@@ -9,7 +11,8 @@ module.exports = function clone(value) {
         dest = isArray(value) ? [] : {};
         var src = value;
         for (var key in src) {
-            if (key[0] === prefix || !hasOwn(src, key)) {
+            if (key[0] === prefix || key[0] === unicodePrefix ||
+                key === $modelCreated || !hasOwn(src, key)) {
                 continue;
             }
             dest[key] = src[key];

--- a/lib/support/isInternalKey.js
+++ b/lib/support/isInternalKey.js
@@ -1,4 +1,5 @@
 var prefix = require("./../internal/prefix");
+var unicodePrefix = require("./../internal/unicodePrefix");
 
 /**
  * Determined if the key passed in is an internal key.
@@ -9,6 +10,7 @@ var prefix = require("./../internal/prefix");
  */
 module.exports = function isInternalKey(x) {
     return x === "$size" ||
-        x === "$absolutePath" ||
-        x && (x.indexOf(prefix) === 0);
+        x === "$modelCreated" ||
+        x.charAt(0) === prefix ||
+        x.charAt(0) === unicodePrefix;
 };

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -8,7 +8,6 @@ var isObject = require("./../support/isObject");
 var isExpired = require("./../support/isExpired");
 var isFunction = require("./../support/isFunction");
 
-var promote = require("./../lru/promote");
 var wrapNode = require("./../support/wrapNode");
 var insertNode = require("./../support/insertNode");
 var expireNode = require("./../support/expireNode");
@@ -42,7 +41,6 @@ module.exports = function mergeJSONGraphNode(
             node = wrapNode(message, undefined, message);
             parent = updateNodeAncestors(parent, -node.$size, lru, version);
             node = insertNode(node, parent, key, undefined, optimizedPath);
-            promote(lru, node);
             return node;
         }
 
@@ -190,8 +188,6 @@ module.exports = function mergeJSONGraphNode(
         // Promote the message edge in the LRU.
         if (isExpired(node)) {
             expireNode(node, expired, lru);
-        } else {
-            promote(lru, node);
         }
     }
     else if (node == null) {

--- a/lib/support/wrapNode.js
+++ b/lib/support/wrapNode.js
@@ -1,10 +1,5 @@
-var jsong = require("falcor-json-graph");
-var $atom = jsong.atom;
-
 var now = require("./../support/now");
 var expiresNow = require("../values/expires-now");
-
-var __modelCreated = require("./../internal/model-created");
 
 var atomSize = 50;
 
@@ -12,6 +7,7 @@ var clone = require("./../support/clone");
 var isArray = Array.isArray;
 var getSize = require("./../support/getSize");
 var getExpires = require("./../support/getExpires");
+var atomType = require("./../types/atom");
 
 module.exports = function wrapNode(nodeArg, typeArg, value) {
 
@@ -20,13 +16,21 @@ module.exports = function wrapNode(nodeArg, typeArg, value) {
     var type = typeArg;
 
     if (type) {
+        var modelCreated = node.$modelCreated;
         node = clone(node);
         size = getSize(node);
         node.$type = type;
+        node.ツprev = undefined;
+        node.ツnext = undefined;
+        node.$modelCreated = modelCreated || false;
     } else {
-        node = $atom(value);
-        type = node.$type;
-        node[__modelCreated] = true;
+        node = {
+            $type: atomType,
+            value: value,
+            ツprev: undefined,
+            ツnext: undefined,
+            $modelCreated: true
+        };
     }
 
     if (value == null) {

--- a/performance/tests/deref/index.js
+++ b/performance/tests/deref/index.js
@@ -32,4 +32,5 @@ function rowTest() {
     var json = seed[0].json;
     var lolomoModel = model.deref(json.lolomo);
     var listsModel = model.deref(json.lolomo[0]);
+    var videoModel = model.deref(json.lolomo[0][0].item);
 }

--- a/performance/tests/get/get.perf.js
+++ b/performance/tests/get/get.perf.js
@@ -69,9 +69,14 @@ function batchingRequests() {
         triggerSource.trigger();
 }
 
-var out = module.exports = {};
+module.exports = function get(out, count) {
+    count = count || 5;
+    out = out || {};
 
-for (var i = 0; i < 5; ++i) {
-    out['primedCache ' + i] = primedCache;
-}
+    for (var i = 0; i < count; ++i) {
+        out['get.primedCache' + i] = primedCache;
+    }
+
+    return out;
+};
 

--- a/performance/tests/lru/index.js
+++ b/performance/tests/lru/index.js
@@ -1,0 +1,26 @@
+var Model = require('./../../../lib').Model;
+var promote = require('./../../../lib/lru/promote');
+var objs = [];
+var root = {};
+
+for (var i = 0; i < 10; i++) {
+    objs[i] = Model.atom(1);
+    promote(root, objs[i]);
+}
+
+function p() {
+    objs.forEach(function(x) {
+        promote(root, x);
+    });
+}
+module.exports = function lru(out, count) {
+    count = count || 5;
+    out = out || {};
+
+    for (var i = 0; i < count; ++i) {
+        out['promote.' + i] = p;
+    }
+
+    return out;
+};
+

--- a/performance/tests/standard.js
+++ b/performance/tests/standard.js
@@ -1,9 +1,11 @@
 var testMerge = require('./testMerge');
-var get = require('./get/get.core.perf');
+var lru = require('./lru');
+var get = require('./get/get.perf');
+var getCore = require('./get/get.core.perf');
 var set = require('./set/set.json-graph.perf');
 var clone = require('./clone/clone.perf');
 
-var standardTest = [get, 5];
+var standardTest = [get, 20];
 
 module.exports = function(name) {
     // Creates the test suites

--- a/test/CacheGenerator.js
+++ b/test/CacheGenerator.js
@@ -39,7 +39,13 @@ function makeVideos(startIdx, count, fields, setModelCreated) {
         videos[i] = {};
 
         fields.forEach(function(f) {
-            videos[i][f] = atom('Video ' + i, setModelCreated && modelCreated || {});
+            var out;
+            if (setModelCreated) {
+                out = atom('Video ' + i, modelCreated);
+            } else {
+                out = atom('Video ' + i);
+            }
+            videos[i][f] = out;
         });
     }
     return videos;

--- a/test/falcor/set/set.setCache.spec.js
+++ b/test/falcor/set/set.setCache.spec.js
@@ -7,7 +7,7 @@ var LocalDataSource = require('../../data/LocalDataSource');
 var clean = require('../../cleanData').stripDerefAndVersionKeys;
 var $ref = Model.ref;
 
-describe('Cache Only', function() {
+describe('Set Cache', function() {
     it("should be fine when you set an empty cache", function(done) {
         var model = new Model({source: new LocalDataSource({
             a: { b: $ref("a"),
@@ -25,6 +25,7 @@ describe('Cache Only', function() {
             a: { b: $ref("a"),
                  c: "foo" }
         })});
+        debugger
         model.setCache(undefined);
         model.get("a.b.c").subscribe(function(x) {
             expect(clean(x)).to.deep.equal({

--- a/test/get-core/get.cache.spec.js
+++ b/test/get-core/get.cache.spec.js
@@ -58,7 +58,7 @@ describe('getCache', function() {
         var cache = model.getCache();
         clean(cache);
         expect(cache).to.deep.equals({
-            test: atom('foo', {$modelCreated: true})
+            test: 'foo'
         });
     });
 });

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -169,7 +169,7 @@ describe('Values', function() {
                 },
                 paths: [['videos', 0, 'title']]
             },
-            cache: cacheGenerator(0, 1)
+            cache: cacheGenerator(0, 1, undefined, false)
         });
     });
     it('should allow for multiple arguments with different length paths as JSONGraph.', function() {

--- a/test/set/support/strip.js
+++ b/test/set/support/strip.js
@@ -1,6 +1,7 @@
 var isArray = Array.isArray;
 var slice = Array.prototype.slice;
 var __prefix = require("../../../lib/internal/prefix");
+var __unicodePrefix = require("../../../lib/internal/unicodePrefix");
 
 module.exports = function strip(cache, allowedKeys) {
     if (cache == null || typeof cache !== "object") {
@@ -17,6 +18,7 @@ module.exports = function strip(cache, allowedKeys) {
                     return obj;
                 } else if (
                     key[0] !== __prefix &&
+                    key[0] !== __unicodePrefix &&
                     key[0] !== "$"      ||
                     ~allowedKeys.indexOf(key)) {
                     obj[key] = strip(cache[key], allowedKeys);


### PR DESCRIPTION
The perf testing for this feature was tested on EC2 instances where
more accurate results could be obtained.  This is showing a significant
performance improvement for the getPath algorithm.  Before this change,
on EC2, a get -> merge -> get for a row representing a full lolomo
request was around 1.7 - 1.8k / s.  After its 1.9 - 2.1k /s.  Second,
primed cache requests went from ~29k to ~60k /s.  Big performance
difference when it comes to using non-dynamic keys.