### PR TITLE
Add bower support for Falcor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,9 @@
+
 {
   "name": "falcor",
-  "version": "1.4.2-build.4091+sha.fe0af2c",
+  "version": "0.1.15",
   "main": "./dist/falcor.browser.js",
   "ignore": [],
-  "dependencies": {},
-  "homepage": "http://netflix.github.io/falcor/",
-  "_source": "https://github.com/Netflix/falcor",
-  "_originalSource": "falcor"
+  "dependencies": {
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "name": "falcor",
   "version": "0.1.15",
   "main": "./dist/falcor.browser.js",
-  "ignore": [],
+  "ignore": ["build", "lib", "examples", "performance", "test"],
   "dependencies": {
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 {
   "name": "falcor",
   "main": "./dist/falcor.browser.js",
-  "ignore": ["build", "lib", "examples", "performance", "test"],
+  "ignore": ["MIGRATIONS.md"],
   "dependencies": {
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "falcor",
+  "version": "1.4.2-build.4091+sha.fe0af2c",
+  "main": "./dist/falcor.browser.js",
+  "ignore": [],
+  "dependencies": {},
+  "homepage": "http://netflix.github.io/falcor/",
+  "_source": "https://github.com/Netflix/falcor",
+  "_originalSource": "falcor"
+}

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,26 @@
 {
   "name": "falcor",
   "main": "./dist/falcor.browser.js",
-  "ignore": ["MIGRATIONS.md"],
+  "ignore": [
+    "build", 
+    "examples", 
+    "lib", 
+    "performance", 
+    "test",
+    ".bithoundrc",
+    ".eslintrc",
+    ".gitignore",
+    ".travis.yml",
+    "all.js",
+    "browser.js",
+    "conf.json",
+    "gulpfile.js",
+    "MIGRATIONS.md",
+    "OSSMETADATA",
+    "package.json",
+    "server.js",
+    "webpack.conf.js"
+    ],
   "dependencies": {
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 
 {
   "name": "falcor",
-  "version": "0.1.15",
   "main": "./dist/falcor.browser.js",
   "ignore": ["build", "lib", "examples", "performance", "test"],
   "dependencies": {


### PR DESCRIPTION
Add support for installing Falcor via bower by adding a bower.json file to the root and defining the main file.

I have registered the fork as falcor-fix in bower so you can check behavior via
```
bower install falcor-fix#0.1.16-alpha3
```

Once you add this bower.json future release tags will become available for install via bower.

Image of what gets installed
![image](https://cloud.githubusercontent.com/assets/1935082/12394860/3ac784c6-bdb3-11e5-9d4a-e2bc26fbf947.png)
