### PR TITLE
0.x fix for the materialized undefined issue.  

### DIFF
--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -40,6 +40,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     // have a dataSource to continue on fetching from.
     var hasValues = results.hasValue;
     var completed = !results.requestedMissingPaths || !model._source;
+    var hasValueOverall = seed[0].json || seed[0].jsonGraph;
 
     // Copy the errors into the total errors array.
     if (results.errors) {
@@ -52,7 +53,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
 
     // If there are values to report, then report.
 
-    if (hasValues && (progressive || completed)) {
+    if (hasValues && progressive || hasValueOverall && completed) {
         // TODO: Remove the sync counter
         try {
             ++model._root.syncRefCount;

--- a/test/data/LocalDataSource.js
+++ b/test/data/LocalDataSource.js
@@ -13,7 +13,7 @@ var LocalSource = module.exports = function(cache, options) {
         wait: false
     }, options);
     this._missCount = 0;
-    this.model = new falcor.Model({cache: cache});
+    this.model = new falcor.Model({cache: cache})._materialize();
 };
 
 LocalSource.prototype = {
@@ -79,6 +79,7 @@ LocalSource.prototype = {
                     errorSelector: errorSelector});
                 jsongEnv = onSet(self, tempModel, jsongEnv);
 
+                tempModel.set(jsongEnv).subscribe();
                 tempModel._getPathValuesAsJSONG(
                     tempModel,
                     jsongEnv.paths,

--- a/test/falcor/error/index.js
+++ b/test/falcor/error/index.js
@@ -125,7 +125,6 @@ describe("Error", function() {
                 expect(onNext.callCount).to.equal(0);
                 expect(onError.calledOnce).to.be.ok;
                 expect(onError.getCall(0).args[0].name).to.equals(InvalidSourceError.name);
-                correct = true;
             }).
             subscribe(noOp, function(e) {
                 if (isAssertionError(e)) {
@@ -166,15 +165,12 @@ describe("Error", function() {
         };
         var model = new falcor.Model({ source: routes });
         var onNext = sinon.spy();
-        var onError = sinon.spy();
         model.
             call(['videos', 1234, 'rating'], 5).
-            doAction(onNext, onError).
-            doAction(noOp, function() {
+            doAction(onNext).
+            doAction(noOp, function(err) {
                 expect(onNext.callCount).to.equal(0);
-                expect(onError.calledOnce).to.be.ok;
-                expect(onError.getCall(0).args[0].name).to.equals(InvalidSourceError.name);
-                correct = true;
+                expect(err.name).to.equals(InvalidSourceError.name);
             }).
             subscribe(noOp, function(e) {
                 if (isAssertionError(e)) {

--- a/test/falcor/get/get.dataSource-and-cache.spec.js
+++ b/test/falcor/get/get.dataSource-and-cache.spec.js
@@ -184,6 +184,40 @@ describe('DataSource and Partial Cache', function() {
                 }).
                 subscribe(noOp, done, noOp);
         });
+
+        it('should ensure that a response where only materialized atoms come ' +
+           'through still onNexts a value if one is present in cache.', function(done) {
+            var model = new Model({
+                cache: {
+                    paths: {
+                        0: 'test',
+                        1: 'test'
+                    }
+                },
+                source: new LocalDataSource({
+                    paths: {
+                        2: Model.atom(undefined),
+                        3: Model.atom(undefined)
+                    }
+                })
+            });
+
+            var onNext = sinon.spy();
+            model.
+                get(['paths', {to:3}]).
+                doAction(onNext, noOp, function() {
+                    expect(onNext.calledOnce, 'onNext called').to.be.ok;
+                    expect(onNext.getCall(0).args[0]).to.deep.equals({
+                        json: {
+                            paths: {
+                                0: 'test',
+                                1: 'test'
+                            }
+                        }
+                    });
+                }).
+                subscribe(noOp, done, done);
+        });
     });
     describe('_toJSONG', function() {
         it('should get multiple arguments into a single _toJSONG response.', function(done) {


### PR DESCRIPTION
If the cache contains values but the requests yields only empty values, then the overall operation will simply complete.