### PR TITLE
DataSource's request are now disposed of

### DIFF
--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -62,39 +62,48 @@ GetRequestV2.prototype = {
         if (!self.scheduled) {
             self.scheduled = true;
 
-            self._disposable = self._scheduler.schedule(function() {
-                flushGetRequest(self, oPaths, function(err, data) {
-                    var i, fn, len;
-                    self.requestQueue.removeRequest(self);
-                    self._disposed = true;
+            var flushedDisposable;
+            var scheduleDisposable = self._scheduler.schedule(function() {
+                flushedDisposable =
+                    flushGetRequest(self, oPaths, function(err, data) {
+                        var i, fn, len;
+                        self.requestQueue.removeRequest(self);
+                        self._disposed = true;
 
-                    if (err instanceof InvalidSourceError) {
-                        for (i = 0, len = callbacks.length; i < len; ++i) {
-                            fn = callbacks[i];
-                            if (fn) {
-                                fn(err);
+                        if (err instanceof InvalidSourceError) {
+                            for (i = 0, len = callbacks.length; i < len; ++i) {
+                                fn = callbacks[i];
+                                if (fn) {
+                                    fn(err);
+                                }
+                            }
+                            return;
+                        }
+
+                        // If there is at least one callback remaining, then
+                        // callback the callbacks.
+                        if (self._count) {
+                            self._merge(rPaths, err, data);
+
+                            // Call the callbacks.  The first one inserts all
+                            // the data so that the rest do not have consider
+                            // if their data is present or not.
+                            for (i = 0, len = callbacks.length; i < len; ++i) {
+                                fn = callbacks[i];
+                                if (fn) {
+                                    fn(err, data);
+                                }
                             }
                         }
-                        return;
-                    }
-
-                    // If there is at least one callback remaining, then
-                    // callback the callbacks.
-                    if (self._count) {
-                        self._merge(rPaths, err, data);
-
-                        // Call the callbacks.  The first one inserts all the
-                        // data so that the rest do not have consider if their
-                        // data is present or not.
-                        for (i = 0, len = callbacks.length; i < len; ++i) {
-                            fn = callbacks[i];
-                            if (fn) {
-                                fn(err, data);
-                            }
-                        }
-                    }
-                });
+                    });
             });
+
+            // There is a race condition here. If the scheduler is sync then it
+            // exposes a condition where the flush request cannot be disposed.
+            // To correct this issue, if there is no flushedDisposable, then the
+            // scheduler is async and should use scheduler disposable, else use
+            // the flushedDisposable.
+            self._disposable = flushedDisposable || scheduleDisposable;
         }
 
         // Disposes this batched request.  This does not mean that the
@@ -219,7 +228,7 @@ function createDisposable(request, idx) {
 
         // If there are no more requests, then dispose all of the request.
         var count = --request._count;
-        if (count === 0 && !request.sent) {
+        if (count === 0) {
             request._disposable.dispose();
             request.requestQueue.removeRequest(request);
         }

--- a/lib/request/flushGetRequest.js
+++ b/lib/request/flushGetRequest.js
@@ -15,7 +15,7 @@ var InvalidSourceError = require("./../errors/InvalidSourceError");
 module.exports = function flushGetRequest(request, listOfPaths, callback) {
     if (request._count === 0) {
         request.requestQueue.removeRequest(request);
-        return;
+        return null;
     }
 
     request.sent = true;
@@ -73,10 +73,11 @@ module.exports = function flushGetRequest(request, listOfPaths, callback) {
             get(collapsedPaths);
     } catch (e) {
         callback(new InvalidSourceError());
-        return;
+        return null;
     }
 
-    getRequest.
+    // Ensures that the disposable is available for the outside to cancel.
+    var disposable = getRequest.
         subscribe(function(data) {
             jsonGraphData = data;
         }, function(err) {
@@ -84,5 +85,7 @@ module.exports = function flushGetRequest(request, listOfPaths, callback) {
         }, function() {
             callback(null, jsonGraphData);
         });
+
+    return disposable;
 };
 

--- a/test/internal/request/GetRequest.spec.js
+++ b/test/internal/request/GetRequest.spec.js
@@ -1,4 +1,217 @@
+var sinon = require('sinon');
+var expect = require('chai').expect;
+var ASAPScheduler = require('./../../../lib/schedulers/ASAPScheduler');
+var Rx = require('rx');
+var Model = require('./../../../lib').Model;
+
 describe('GetRequest', function() {
     require('./GetRequest.batch.spec');
     require('./GetRequest.add.spec');
+
+    it('unsubscribing should cancel DataSource request (sync scheduler).', function() {
+        var unsubscribeSpy;
+        var subscribeSpy = sinon.spy(function(observerOrOnNext, onError, onCompleted) {
+            var handle = setTimeout(function() {
+                var response = {
+                    jsonGraph: {
+                        list: {
+                            1: { name: "another test" }
+                        }
+                    },
+                    paths: ["list", 1, "name"]
+                };
+
+                if (typeof observerOrOnNext === "function") {
+                    observerOrOnNext(response);
+                    onCompleted();
+                }
+                else {
+                    observerOrOnNext.onNext(response);
+                    observerOrOnNext.onCompleted();
+                }
+            });
+
+            unsubscribeSpy = sinon.spy(function() {
+                clearTimeout(handle);
+            });
+
+            return {
+                dispose: unsubscribeSpy
+            };
+        });
+
+        var model = new Model({
+            cache: {
+                list: {
+                    0: { name: "test" }
+                }
+            },
+            source: {
+                get: function() {
+                    return {
+                        subscribe: subscribeSpy
+                    }
+                }
+            }
+        });
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy();
+        var onCompleted = sinon.spy();
+
+        var subscription = model.get("list[0,1].name").
+            subscribe(onNext, onError, onCompleted);
+
+        subscription.dispose();
+
+        if (!subscribeSpy.calledOnce) {
+            throw new Error("subscribe not called.");
+        }
+        if (!unsubscribeSpy.calledOnce) {
+            throw new Error("DataSource unsubscribe not called.");
+        }
+
+        if (onNext.callCount + onError.callCount + onCompleted.callCount !== 0) {
+            throw new Error("onNext, onError, or onCompleted was called.");
+        }
+    });
+
+    it('unsubscribing should cancel DataSource request (async scheduler, unsubscribed immediate).', function() {
+        var subscribeSpy = sinon.spy(function(observerOrOnNext, onError, onCompleted) {
+            var handle = setTimeout(function() {
+                var response = {
+                    jsonGraph: {
+                        list: {
+                            1: { name: "another test" }
+                        }
+                    },
+                    paths: ["list", 1, "name"]
+                };
+
+                if (typeof observerOrOnNext === "function") {
+                    observerOrOnNext(response);
+                    onCompleted();
+                }
+                else {
+                    observerOrOnNext.onNext(response);
+                    observerOrOnNext.onCompleted();
+                }
+            });
+
+            // No need to have a spy, if subscribe is called, we fail.
+            return {
+                dispose: function() {}
+            };
+        });
+
+        var model = new Model({
+            scheduler: new ASAPScheduler(),
+            cache: {
+                list: {
+                    0: { name: "test" }
+                }
+            },
+            source: {
+                get: function() {
+                    return {
+                        subscribe: subscribeSpy
+                    }
+                }
+            }
+        });
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy();
+        var onCompleted = sinon.spy();
+
+        var subscription = model.get("list[0,1].name").
+            subscribe(onNext, onError, onCompleted);
+
+        subscription.dispose();
+
+        if (subscribeSpy.callCount !== 0) {
+            throw new Error("subscribe called at least once.");
+        }
+
+        if (onNext.callCount + onError.callCount + onCompleted.callCount !== 0) {
+            throw new Error("onNext, onError, or onCompleted was called.");
+        }
+    });
+
+    it('unsubscribing should cancel DataSource request (async scheduler, unsubscribed after subscribe).', function(done) {
+        var unsubscribeSpy;
+        var subscribeSpy = sinon.spy(function(observerOrOnNext, onError, onCompleted) {
+            var handle = setTimeout(function() {
+                var response = {
+                    jsonGraph: {
+                        list: {
+                            1: { name: "another test" }
+                        }
+                    },
+                    paths: ["list", 1, "name"]
+                };
+
+                if (typeof observerOrOnNext === "function") {
+                    observerOrOnNext(response);
+                    onCompleted();
+                }
+                else {
+                    observerOrOnNext.onNext(response);
+                    observerOrOnNext.onCompleted();
+                }
+            }, 100000);
+
+            unsubscribeSpy = sinon.spy(function() {
+                clearTimeout(handle);
+            });
+
+            return {
+                dispose: unsubscribeSpy
+            };
+        });
+
+        var model = new Model({
+            cache: {
+                list: {
+                    0: { name: "test" }
+                }
+            },
+            source: {
+                get: function() {
+                    return {
+                        subscribe: subscribeSpy
+                    }
+                }
+            }
+        });
+
+        var onNext = sinon.spy();
+        var onError = sinon.spy();
+        var onCompleted = sinon.spy();
+
+        var subscription = model.get("list[0,1].name").
+            subscribe(onNext, onError, onCompleted);
+
+        function waitOrExpect() {
+            if (!unsubscribeSpy) {
+                setTimeout(waitOrExpect, 0);
+                return;
+            }
+            subscription.dispose();
+
+            if (!subscribeSpy.calledOnce) {
+                return done(new Error("subscribe not called."));
+            }
+            if (!unsubscribeSpy.calledOnce) {
+                return done(new Error("DataSource unsubscribe not called."));
+            }
+
+            if (onNext.callCount + onError.callCount + onCompleted.callCount !== 0) {
+                return done(new Error("onNext, onError, or onCompleted was called."));
+            }
+            return done();
+        }
+        waitOrExpect();
+
+    });
 });


### PR DESCRIPTION
@jhusain the tests show all the possible outcomes now.  There was a fun race condition I had to fix when it comes to sync scheduling (ImmediateScheduler) and flushing requests.