### PR TITLE
Make Model#_clone return instance of current type

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -425,7 +425,7 @@ Model.prototype._syncCheck = function syncCheck(name) {
 
 /* eslint-disable guard-for-in */
 Model.prototype._clone = function cloneModel(opts) {
-    var clone = new Model(this);
+    var clone = new this.constructor(this);
     for (var key in opts) {
         var value = opts[key];
         if (value === "delete") {


### PR DESCRIPTION
If I subclass `Model` like so:

``` js
class MyModel extends Model { ... }
var model = new MyModel().batch();
```

`batch()` nevertheless returns an instance of `Model`. This PR makes it so `batch()` and other cloning methods would return instances of `MyModel`.
