### PR TITLE
Commit docs to branch on developer site build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ bin/
 bin2
 out/
 tmp/
-doc/
 performance/bin/
 performance/device/
 !tasks/bin

--- a/build/deploy-ghpages.sh
+++ b/build/deploy-ghpages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  echo -e "Building and committing dist...\n"
+  echo -e "Building and committing dist and docs...\n"
 
   TEMP_DIR=$HOME/tmp
   FALCOR_DOCS_DIR=$TEMP_DIR/falcordocs
@@ -36,7 +36,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   npm run dist
 
   git add dist/.
-  git commit -m "Travis build $TRAVIS_BUILD_NUMBER committed dist/"
+  git add doc/.
+  git commit -m "Travis build $TRAVIS_BUILD_NUMBER committed dist/ and doc/"
   git push deployable $TRAVIS_BRANCH
 
   if [ "$TRAVIS_BRANCH" == "$CURRENT_RELEASE" ]; then


### PR DESCRIPTION
@sdesai CC @ktrott 

Context: for the new Falcor site, the docs for each site version will be pulled in from the corresponding branch in this repo (e.g. once 1.x is master, site version 1.x will get docs from master and version 0.x from this repo's 0.x branch).

I left the jsdocs output the same because the new site can consume it as-is, and the part that commits to gh-pages directly doesn't need to be removed until the new site is launched.

This looked to me like the best place to commit the docs for the branch on a travis build, but please let me know if there's somewhere better and I'm happy to help make the changes.

Thanks!