### PR TITLE
Grammar, spelling, and formatting fixes in documentation

### DIFF
--- a/documentation/datasources.md
+++ b/documentation/datasources.md
@@ -179,7 +179,7 @@ response.subscribe(jsonGraphEnvelope => JSON.stringify(jsonGraphEnvelope, null, 
 
 The `call` method on the DataSource interface executes the abstract [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) call operation on the DataSource's associated [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object. The `call` method invokes a single function located inside of the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object.
 
-Functions are useful for non-idempotent operations which cannot be performed using `get` or `set` (ex. like adding to a list). Using a Function is appropriate when the application is performing a transactional operation that cannot be represented as a series of set operation.
+Functions are useful for non-idempotent operations which cannot be performed using `get` or `set` (ex. like adding to a list). Using a Function is appropriate when the application is performing a transactional operation that cannot be represented as a series of set operations.
 
 [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) Functions can _not_ return transient data (ex. 2 + 2 = 4). A [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) function can only return a JSONGraphEnvelope containing a subset of the data in its "this" object (the object which contains the function as a member).
 
@@ -194,17 +194,17 @@ interface DataSource {
 ~~~
 
 
-Note that one invocation of call can only run a single function. The callPath argument is the path to the function within the DataSource’s JSON Graph object. The args parameter is the array of arguments to be passed to the function being called.
+Note that one invocation of call can only run a single function. The callPath argument is the path to the function within the DataSource's JSON Graph object. The args parameter is the array of arguments to be passed to the function being called.
 
 The refPaths argument is the array of PathSets to retrieve from the JSON Graph References within the function response. The dataSource appends these pathSets to any JSON Graph References that appear within the function response, and adds the values to the JSONGraphEnvelope. Typically, refPaths are used when the function creates a new object and returns a reference to that object. The refPaths can be passed to the call method in order to allow fields to be retrieved from the newly-generated object without the need for a subsequent get operation.
 
-A function is not obligated to return all of the changes that it makes to its “this” object. On the contrary, functions typically return as little data as possible by default. The thisPaths argument is the array of PathSets to retrieve from the function's "this" object after the function has completed execution. The DataSource adds these values to the JSONGraphEnvelope before returning the function's response. 
+A function is not obligated to return all of the changes that it makes to its "this" object. On the contrary, functions typically return as little data as possible by default. The thisPaths argument is the array of PathSets to retrieve from the function's "this" object after the function has completed execution. The DataSource adds these values to the JSONGraphEnvelope before returning the function's response. 
 
 
 
-Instead of forcing functions to return all of the changes they make to the JSON Graph object, DataSources allow callers to define exactly which values they would like to refresh after successful function execution. To this end, callers can provide refPaths and thisPaths to the DataSource’s call method along with the function path. After the DataSource runs the function, it retrieves the refPaths and thisPaths and adds them to the JSON Graph response.
+Instead of forcing functions to return all of the changes they make to the JSON Graph object, DataSources allow callers to define exactly which values they would like to refresh after successful function execution. To this end, callers can provide refPaths and thisPaths to the DataSource's call method along with the function path. After the DataSource runs the function, it retrieves the refPaths and thisPaths and adds them to the JSON Graph response.
 
-After the refPaths have been evaluated against any JSON Graph References returned by the function and added to the JSONGraphEnvelope Response, each PathSet in the thisPaths array is evaluated on the function’s “this” object. The resulting values are added to the JSON Graph Response returned by the DataSource’s call method.
+After the refPaths have been evaluated against any JSON Graph References returned by the function and added to the JSONGraphEnvelope Response, each PathSet in the thisPaths array is evaluated on the function's "this" object. The resulting values are added to the JSON Graph Response returned by the DataSource's call method.
 
 To demonstrate the `call()` method in action, we'll create a [Router](http://netflix.github.io/falcor/documentation/router.html) DataSource that allows titles to be pushed into a Netflix member's list.  
 

--- a/documentation/jsongraph.md
+++ b/documentation/jsongraph.md
@@ -45,7 +45,7 @@ Note that in the example above the JSON Graph contains references to other locat
 
 JSON is a ubiquitous data interchange format. Web applications often exchange data in JSON format because manipulating JSON Data in JavaScript is so easy. JSON is also map–based, which makes it easy to divide a large data set into smaller subsets and send them across the wire on demand.
 
-Unfortunately there is a downside to using JSON to send and store your Web application's data: JSON models trees, and most application domains are *graphs*. As a result, serializing a graph as JSON can introduce duplicates copies of the same entity. 
+Unfortunately there is a downside to using JSON to send and store your Web application's data: JSON models trees, and most application domains are *graphs*. As a result, serializing a graph as JSON can introduce duplicate copies of the same entity. 
 ![Graph to JSON](../images/jsong-json.png)
 
 These duplicates take up additional space when sent across the wire, but they can also create a much bigger hazard: **stale data**. If changes made to one instance of an entity are not propagated to the others, the application may present stale data to the user if they are presented a different instance than the one they changed. 
@@ -99,23 +99,23 @@ The code above will eventually return a response that contains "withdraw money f
 
 ## New Primitive Value Types 
 
-In addition to JSON’s primitive types, JSON Graph introduces three new primitive types:  
+In addition to JSON's primitive types, JSON Graph introduces three new primitive types:  
 
 1. Reference  
 2. Atom  
 3. Error   
 
-Each of these types is a JSON Graph object with a "$type" key that differentiates it from regular JSON objects, and describes the type of its “value” key. These three JSON Graph primitive types are always retrieved and replaced in their entirety just like a primitive JSON value.  None of the JSON Graph values can be mutated using any of the available abstract JSON Graph operations.
+Each of these types is a JSON Graph object with a "$type" key that differentiates it from regular JSON objects, and describes the type of its "value" key. These three JSON Graph primitive types are always retrieved and replaced in their entirety just like a primitive JSON value.  None of the JSON Graph values can be mutated using any of the available abstract JSON Graph operations.
 
 ### Reference   
 
-A Reference is a JSON object with a “$type” key that has a value of “ref” and a ”value” key that has a [Path](http://netflix.github.io/falcor/documentation/paths.html) array as its value. 
+A Reference is a JSON object with a "$type" key that has a value of "ref" and a "value" key that has a [Path](http://netflix.github.io/falcor/documentation/paths.html) array as its value. 
 
 ~~~js
 { $type: "ref", value: ["todosById", 44] }
 ~~~
 
-A Reference’s [Path](http://netflix.github.io/falcor/documentation/paths.html) points to another location within the same JSON Graph object. Using References, it is possible to model a graph in JSON. Here is an example of a TODO list in which each task can contain References to its prerequisite tasks: 
+A Reference's [Path](http://netflix.github.io/falcor/documentation/paths.html) points to another location within the same JSON Graph object. Using References, it is possible to model a graph in JSON. Here is an example of a TODO list in which each task can contain References to its prerequisite tasks: 
 
 ~~~js
 {
@@ -142,7 +142,7 @@ A Reference is like a symbolic link in the UNIX file system. When the [Path](htt
 
 ### Atom
 
-An Atom is a JSON object with a “$type” key that has a value of “atom” and a ”value” key that contains a JSON value.
+An Atom is a JSON object with a "$type" key that has a value of "atom" and a "value" key that contains a JSON value.
 
 ~~~js
 { $type: "atom", value: ['en', 'fr'] }
@@ -207,7 +207,7 @@ The result above only includes the value of the Atom because the [Model](http://
 
 ### Error
 
-An Error is a JSON object with a “$type” key that has a value of “error” and a ”value” key that contains an error that occured while executing a JSON Graph operation.
+An Error is a JSON object with a "$type" key that has a value of "error" and a "value" key that contains an error that occured while executing a JSON Graph operation.
 
 ~~~js
 { $type: "error", value: "The request timed out." }
@@ -264,7 +264,7 @@ There are three abstract operations that can be carried out on a JSON Graph obje
 2. set 
 3. call   
 
-Each of these operations must be carried out by an intermediary. This layer of indirection allows us the true location and organization of the data to be abstracted away from the caller.
+Each of these operations must be carried out by an intermediary. This layer of indirection allows the true location and organization of the data to be abstracted away from the caller.
  
 Some examples of objects that are capable of carrying out the abstract JSON Graph operations are:  
 
@@ -313,13 +313,13 @@ Let's walk through an abstract get operation on an example JSON Graph object:
 }
 ~~~
 
-Let’s evaluate the following [Path](http://netflix.github.io/falcor/documentation/paths.html) in an attempt to retrieve the name of the first task in the TODOs list.
+Let's evaluate the following [Path](http://netflix.github.io/falcor/documentation/paths.html) in an attempt to retrieve the name of the first task in the TODOs list.
 
 ~~~js
 ["todos", 0, "name"]
 ~~~
 
-First we evaluate the ”todos” key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number “0” key, and it is converted into a string using JSON stringify algorithm. We attempt to look up the value in the array, and we find a reference:  
+First we evaluate the "todos" key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number "0" key, and it is converted into a string using JavaScript's toString algorithm. We attempt to look up the value in the array, and we find a reference:  
 
 ~~~js
 // JSON Graph object
@@ -357,7 +357,7 @@ References are primitive value types, and are therefore immediately inserted int
 }
 ~~~
 
-References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. If a Reference is encountered when there are still keys left in the [path](http://netflix.github.io/falcor/documentation/paths.html) to be evaluated, a new [Path](http://netflix.github.io/falcor/documentation/paths.html) is created. The new [Path](http://netflix.github.io/falcor/documentation/paths.html) is formed by concatenating the remaining keys to the end of the reference [Path](http://netflix.github.io/falcor/documentation/paths.html). This process is known as “path optimization”, because the optimized [Path](http://netflix.github.io/falcor/documentation/paths.html) we create is a quicker route to the requested value. [Path](http://netflix.github.io/falcor/documentation/paths.html) optimization produces the following [Path](http://netflix.github.io/falcor/documentation/paths.html):  
+References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. If a Reference is encountered when there are still keys left in the [path](http://netflix.github.io/falcor/documentation/paths.html) to be evaluated, a new [Path](http://netflix.github.io/falcor/documentation/paths.html) is created. The new [Path](http://netflix.github.io/falcor/documentation/paths.html) is formed by concatenating the remaining keys to the end of the reference [Path](http://netflix.github.io/falcor/documentation/paths.html). This process is known as "path optimization", because the optimized [Path](http://netflix.github.io/falcor/documentation/paths.html) we create is a quicker route to the requested value. [Path](http://netflix.github.io/falcor/documentation/paths.html) optimization produces the following [Path](http://netflix.github.io/falcor/documentation/paths.html):  
 
 ~~~js
 ["todosById", 44].concat(["name"]) // ["todosById", 44, "name"]
@@ -395,7 +395,7 @@ Once we create an optimized [Path](http://netflix.github.io/falcor/documentation
 }
 ~~~
 
-Now we evaluate the “todosById” key, which yields an object. Next, we convert the number 44 into a string using the JSON stringify algorithm. Then we look up the resulting string “44” which yields another object. Finally we look up the key “name” and we find a primitive value type ”get milk from corner store”. This value is added to the JSON Graph subset and returned as the result of the abstract get operation. 
+Now we evaluate the "todosById" key, which yields an object. Next, we convert the number 44 into a string using JavaScript's toString algorithm. Then we look up the resulting string "44" which yields another object. Finally we look up the key "name" and we find a primitive value type "get milk from corner store". This value is added to the JSON Graph subset and returned as the result of the abstract get operation. 
 
 ~~~js
 // JSON Graph Envelope response
@@ -415,7 +415,7 @@ Now we evaluate the “todosById” key, which yields an object. Next, we conver
 
 ###  Retrieving References  
 
-As we saw in the previous section, when references are encountered while there are still keys in the [Path](http://netflix.github.io/falcor/documentation/paths.html) left to be evaluated, the [Path](http://netflix.github.io/falcor/documentation/paths.html) is optimized. However, if the reference is encountered and there are no more keys in the [Path](http://netflix.github.io/falcor/documentation/paths.html) left to be evaluated, the reference itself is returned rather than its target object. To see this process in action, let’s start with the same JSON Graph document we used in the previous section:    
+As we saw in the previous section, when references are encountered while there are still keys in the [Path](http://netflix.github.io/falcor/documentation/paths.html) left to be evaluated, the [Path](http://netflix.github.io/falcor/documentation/paths.html) is optimized. However, if the reference is encountered and there are no more keys in the [Path](http://netflix.github.io/falcor/documentation/paths.html) left to be evaluated, the reference itself is returned rather than its target object. To see this process in action, let's start with the same JSON Graph document we used in the previous section:    
 
 ~~~js
 {
@@ -438,13 +438,13 @@ As we saw in the previous section, when references are encountered while there a
 };
 ~~~
 
-Let’s evaluate the following [Path](http://netflix.github.io/falcor/documentation/paths.html) to retrieve the reference to the first task in the TODO list:
+Let's evaluate the following [Path](http://netflix.github.io/falcor/documentation/paths.html) to retrieve the reference to the first task in the TODO list:
 
 ~~~js
 ["todos", 0]
 ~~~
 
-First we evaluate the ”todos” key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number “0” key, and it is converted into a string using JSON stringify algorithm. We attempt to look up the value in the array, and we find a reference:  
+First we evaluate the "todos" key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number "0" key, and it is converted into a string using JavaScript's toString algorithm. We attempt to look up the value in the array, and we find a reference:  
 
 ~~~js
 {
@@ -471,7 +471,7 @@ References are primitive value types, and are therefore inserted into the subset
 
 ### Short-circuiting   
 
-If a primitive value is encountered while evaluating a [Path](http://netflix.github.io/falcor/documentation/paths.html), the get operation short-circuits, and the value type is included in the JSON Graph subset that is returned as the result of the abstract get operation. Let’s take a look at this process in action. We will start with the same JSON Graph object we used in the previous section: 
+If a primitive value is encountered while evaluating a [Path](http://netflix.github.io/falcor/documentation/paths.html), the get operation short-circuits, and the value type is included in the JSON Graph subset that is returned as the result of the abstract get operation. Let's take a look at this process in action. We will start with the same JSON Graph object we used in the previous section: 
 
 ~~~js
 {
@@ -494,13 +494,13 @@ If a primitive value is encountered while evaluating a [Path](http://netflix.git
 };
 ~~~
 
-This time we will attempt to retrieve the name of the 9th item from the TODO list, even though the list is only three items long.   
+This time we will attempt to retrieve the name of the 9th item from the TODO list, even though the list is only two items long.   
 
 ~~~js
 ["todos", 9, "name"]
 ~~~
 
-First we evaluate the ”todos” key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the “9” key, and it is converted into a string using JSON stringify algorithm. We attempt to look up the value in the array, which yield an undefined value. The undefined value is added to the JSON Graph subset, which is returned as the result of the abstract get operation:
+First we evaluate the "todos" key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the "9" key, and it is converted into a string using JavaScript's toString algorithm. We attempt to look up the value in the array, which yield an undefined value. The undefined value is added to the JSON Graph subset, which is returned as the result of the abstract get operation:
 
 ~~~js
 // JSON Graph Envelope response
@@ -515,9 +515,9 @@ First we evaluate the ”todos” key, which yields an array.  There are more ke
 
 ### The Abstract set Operation  
 
-In addition to retrieving values from a JSON graph object, it is possible to set values into a JSON Graph object. The abstract set operation accepts multiple [Path](http://netflix.github.io/falcor/documentation/paths.html)/value pairs. It returns a subset of the JSON Graph that contains all of the References encountered during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation, as well as the values inserted into the JSON Graph. It is only legal to set primitive values into a JSON Graph object. A single set operation should modify only one value in the JSON Graph for each input [Path](http://netflix.github.io/falcor/documentation/paths.html). If it is necessary to set values at [paths](http://netflix.github.io/falcor/documentation/paths.html) which cannot be known ahead of time, you must use an abstract call operation instead. Set operations must be idempotent. 
+In addition to retrieving values from a JSON graph object, it is possible to set values into a JSON Graph object. The abstract set operation accepts multiple [Path](http://netflix.github.io/falcor/documentation/paths.html)/value pairs. It returns a subset of the JSON Graph that contains all of the References encountered during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation, as well as the values inserted into the JSON Graph. It is only legal to set primitive values into a JSON Graph object. A single set operation should modify only one value in the JSON Graph for each input [Path](http://netflix.github.io/falcor/documentation/paths.html). If it is necessary to set values at [Paths](http://netflix.github.io/falcor/documentation/paths.html) which cannot be known ahead of time, you must use an abstract call operation instead. Set operations must be idempotent. 
 
-Let’s walk through this process using the same JSON graph object we used in the previous section.  
+Let's walk through this process using the same JSON graph object we used in the previous section.  
 
 ~~~js
 {
@@ -540,13 +540,13 @@ Let’s walk through this process using the same JSON graph object we used in th
 };
 ~~~
 
-We will attempt to mark the first task in the TODOs list as done using the following [Path](http://netflix.github.io/falcor/documentation/paths.html)/value combination:  
+We will attempt to mark the first task in the TODO list as done using the following [Path](http://netflix.github.io/falcor/documentation/paths.html)/value combination:  
 
 ~~~js
 { path: ["todos", 0, "done"], value: true }
 ~~~
 
-First we evaluate the ”todos” key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number “0” key, and it is converted into a string using JSON stringify algorithm. We attempt to look up the value in the array, and we find a reference:  
+First we evaluate the "todos" key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number "0" key, and it is converted into a string using JavaScrtip's toString algorithm. We attempt to look up the value in the array, and we find a reference:  
 
 ~~~js
 // JSON Graph object
@@ -563,7 +563,7 @@ First we evaluate the ”todos” key, which yields an array.  There are more ke
 }
 ~~~
 
-References are primitive value types, and are therefore immediately inserted into the subset of the JSON Graph object that will be produced by the abstract set operation. However References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. If a Reference is encountered when there are still keys left in the [Path](http://netflix.github.io/falcor/documentation/paths.html) to be evaluated, a new [Path](http://netflix.github.io/falcor/documentation/paths.html) is created by concatenating the keys that have yet to be evaluated to the end of the reference [Path](http://netflix.github.io/falcor/documentation/paths.html). This process is known as “path optimization”, because the optimized [Path](http://netflix.github.io/falcor/documentation/paths.html) we create is a quicker route to the requested value. [Path](http://netflix.github.io/falcor/documentation/paths.html) optimization produces the following [Path](http://netflix.github.io/falcor/documentation/paths.html): 
+References are primitive value types, and are therefore immediately inserted into the subset of the JSON Graph object that will be produced by the abstract set operation. However References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. If a Reference is encountered when there are still keys left in the [Path](http://netflix.github.io/falcor/documentation/paths.html) to be evaluated, a new [Path](http://netflix.github.io/falcor/documentation/paths.html) is created by concatenating the keys that have yet to be evaluated to the end of the reference [Path](http://netflix.github.io/falcor/documentation/paths.html). This process is known as "path optimization", because the optimized [Path](http://netflix.github.io/falcor/documentation/paths.html) we create is a quicker route to the requested value. [Path](http://netflix.github.io/falcor/documentation/paths.html) optimization produces the following [Path](http://netflix.github.io/falcor/documentation/paths.html): 
 
 ~~~js
 ["todosById", 44].concat(["done"]) // ["todosById", 44, "done"]
@@ -601,7 +601,7 @@ Once we create an optimized [Path](http://netflix.github.io/falcor/documentation
 }
 ~~~
 
-Now we evaluate the “todosById” key, which yields an object. Next, we convert the number 44 into a string using the JSON stringify algorithm. Then we look up the resulting string “44” which yields another object. Finally we arrive at the last key: “done”. We replace the value at this location with the new value: true. We also insert the value into the JSON Graph subset, and return the JSON Graph subset as the new result of the abstract set operation. 
+Now we evaluate the "todosById" key, which yields an object. Next, we convert the number 44 into a string using JavaScript's toString algorithm. Then we look up the resulting string "44" which yields another object. Finally we arrive at the last key: "done". We replace the value at this location with the new value: true. We also insert the value into the JSON Graph subset, and return the JSON Graph subset as the new result of the abstract set operation. 
 
 ~~~js
 // JSON Graph object
@@ -640,7 +640,7 @@ Now we evaluate the “todosById” key, which yields an object. Next, we conver
 
 #### Setting Beyond Primitive Values  
 
-As we saw in the previous section, if we encounter a Reference while setting a [Path](http://netflix.github.io/falcor/documentation/paths.html), the Reference [Path](http://netflix.github.io/falcor/documentation/paths.html) is followed to the target object. As we now know, References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. However if we encounter a primitive value while setting a value into the JSON Graph object, then the primitive value is replaced with an object and the abstract set operation continues. Let’s see an example of this in practice. We will start with the same JSON graph object we used in the previous section:  
+As we saw in the previous section, if we encounter a Reference while setting a [Path](http://netflix.github.io/falcor/documentation/paths.html), the Reference [Path](http://netflix.github.io/falcor/documentation/paths.html) is followed to the target object. As we now know, References are handled specially during [Path](http://netflix.github.io/falcor/documentation/paths.html) evaluation. However if we encounter a primitive value while setting a value into the JSON Graph object, then the primitive value is replaced with an object and the abstract set operation continues. Let's see an example of this in practice. We will start with the same JSON graph object we used in the previous section:  
 
 ~~~js
 {
@@ -663,13 +663,13 @@ As we saw in the previous section, if we encounter a Reference while setting a [
 };
 ~~~
 
-This time we will attempt to replace the ”done” key value with an object that contains one value: a boolean indicating that the task was completed. We will set the following [Path](http://netflix.github.io/falcor/documentation/paths.html)/value pair:
+This time we will attempt to replace the "done" key value with an object that contains one value: a boolean indicating that the task was completed. We will set the following [Path](http://netflix.github.io/falcor/documentation/paths.html)/value pair:
 
 ~~~js
 { path: ["todos", 0, "done", "completed"], value: true }
 ~~~
 
-First we evaluate the ”todos” key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number “0” key, and it is converted into a string using JSON stringify algorithm. We attempt to look up the value in the array, and we find a reference:  
+First we evaluate the "todos" key, which yields an array.  There are more keys to be evaluated, so we continue. Then we evaluate the number "0" key, and it is converted into a string using JavaScript's toString algorithm. We attempt to look up the value in the array, and we find a reference:  
 
 ~~~js
 // JSON Graph object
@@ -724,7 +724,7 @@ Once we create an optimized [Path](http://netflix.github.io/falcor/documentation
 }
 ~~~
 
-Now we evaluate the “todosById” key, which yields an object. Next, we convert the number 44 into a string using the JSON stringify algorithm. Then we look up the resulting string “44” which yields another object. Now we look up the ”done” key and find a primitive value: false. As there are more keys to be evaluated, the object evaluating the abstract set operation attempts to replace the primitive value with an object. 
+Now we evaluate the "todosById" key, which yields an object. Next, we convert the number 44 into a string using the JavaScript's toString algorithm. Then we look up the resulting string "44" which yields another object. Now we look up the "done" key and find a primitive value: false. As there are more keys to be evaluated, the object evaluating the abstract set operation attempts to replace the primitive value with an object. 
 
 ~~~js
 // setting ["todosById", 44, "done", "completed"] to true
@@ -749,7 +749,7 @@ Now we evaluate the “todosById” key, which yields an object. Next, we conver
 }
 ~~~
 
-Now that we have reached the final key “completed”, we insert the boolean value “true” that key within the object we previously created. The value is also added at the same location within the JSON Graph subset, and returned as the result of the abstract set operation.
+Now that we have reached the final key, "completed", we insert the boolean value "true" that key within the object we previously created. The value is also added at the same location within the JSON Graph subset, and returned as the result of the abstract set operation.
 
 ~~~js
 // setting ["todosById", 44, "done", "completed"] to true
@@ -795,13 +795,13 @@ The object evaluating the abstract set operation may choose to coerce the value 
 }
 ~~~
         
-Let’s attempt to set the user rating of the title to 9, even though the only ratings allowed are between 1 and 5.   
+Let's attempt to set the user rating of the title to 9, even though the only ratings allowed are between 1 and 5.   
 
 ~~~js
 { path: ["titlesById", 253, "userRating"], value: 9 }
 ~~~
 
-Firstly evaluate the “titlesById” key. We find an object, so we continue. We evaluate the number “253” key, and convert it into a string using the JSON stringify method. We find another object, so we continue. Finally we attempt to set the ”userRating” key to “9”, and the object evaluating the abstract set operation instead sets the rating to the upper bound of valid values: “5”. The number five is inserted in both the JSON Graph object, as well as the JSON Graph subset. The JSON Graph subset response is returned as the result of the abstract set operation. 
+Firstly evaluate the "titlesById" key. We find an object, so we continue. We evaluate the number "253" key, and convert it into a string using the JSON stringify method. We find another object, so we continue. Finally we attempt to set the "userRating" key to "9", and the object evaluating the abstract set operation instead sets the rating to the upper bound of valid values: "5". The number five is inserted in both the JSON Graph object, as well as the JSON Graph subset. The JSON Graph subset response is returned as the result of the abstract set operation. 
 
 ~~~js
 // JSON Graph object
@@ -835,7 +835,7 @@ A JSON Graph object is not a strict subset of JSON. Unlike JSON objects, JSON Gr
 
 Like JavaScript objects, functions can appear anywhere in the JSON Graph object. Like other non-primitive values, functions cannot be retrieved or set using the abstract get or set operations. It is only possible to call a function, and pass it arguments.  
 
-In order to call a function, you must specify the [Path](http://netflix.github.io/falcor/documentation/paths.html) to the function, as well as the arguments to pass to the function. The arguments can be any JSON Graph value other than a function, including arrays, objects, and the primitive values.  A function must either return the new value at every [Path](http://netflix.github.io/falcor/documentation/paths.html) it has changed, or add the [Path](http://netflix.github.io/falcor/documentation/paths.html) to  the list of invalidated [paths](http://netflix.github.io/falcor/documentation/paths.html). The invalidated [paths](http://netflix.github.io/falcor/documentation/paths.html) are a list of [paths](http://netflix.github.io/falcor/documentation/paths.html) that may have been changed by the function. The invalidated [paths](http://netflix.github.io/falcor/documentation/paths.html) are included in the function’s response along with the JSON Graph subset. Callers remove the invalidated [paths](http://netflix.github.io/falcor/documentation/paths.html) from their local cache to ensure that their cache does not contain stale data. Let’s walk through the process of adding an item to a list using call. 
+In order to call a function, you must specify the [Path](http://netflix.github.io/falcor/documentation/paths.html) to the function, as well as the arguments to pass to the function. The arguments can be any JSON Graph value other than a function, including arrays, objects, and the primitive values.  A function must either return the new value at every [Path](http://netflix.github.io/falcor/documentation/paths.html) it has changed, or add the [Path](http://netflix.github.io/falcor/documentation/paths.html) to  the list of invalidated [Paths](http://netflix.github.io/falcor/documentation/paths.html). The invalidated [Paths](http://netflix.github.io/falcor/documentation/paths.html) are a list of [Paths](http://netflix.github.io/falcor/documentation/paths.html) that may have been changed by the function. The invalidated [Paths](http://netflix.github.io/falcor/documentation/paths.html) are included in the function's response along with the JSON Graph subset. Callers remove the invalidated [Paths](http://netflix.github.io/falcor/documentation/paths.html) from their local cache to ensure that their cache does not contain stale data. Let's walk through the process of adding an item to a list using call. 
 
 For this example, let's start with the following JSON Graph object:
 
@@ -881,9 +881,9 @@ The "callPath" is the [Path](http://netflix.github.io/falcor/documentation/paths
 
 The "arguments" parameter is the array of arguments to be passed to the function being called.
 
-The "refPaths" is an array of [paths](http://netflix.github.io/falcor/documentation/paths.html) to retrieve from the targets of any references in the JSON Graph Envelope returned by the function. 
+The "refPaths" is an array of [Paths](http://netflix.github.io/falcor/documentation/paths.html) to retrieve from the targets of any references in the JSON Graph Envelope returned by the function. 
 
-The "thisPaths" is an array of [paths](http://netflix.github.io/falcor/documentation/paths.html) to retrieve from the object on which the function is called after the function is successfully excecuted.
+The "thisPaths" is an array of [Paths](http://netflix.github.io/falcor/documentation/paths.html) to retrieve from the object on which the function is called after the function is successfully excecuted.
 
 Here is how we invoke the abstract call operation:
 
@@ -964,7 +964,7 @@ Now the object executing the abstract call operation retrieves the refPaths from
 ["todos", "2"].concat(["addedAt"]) // produces ["todos", "2", "addedAt"]
 ~~~
 
-The object executing the abstract call operation now executes the abstract get operation to retrieve these newly-created [paths](http://netflix.github.io/falcor/documentation/paths.html). The resulting JSON Graph Envelope is merged together with the function's response:
+The object executing the abstract call operation now executes the abstract get operation to retrieve these newly-created [Paths](http://netflix.github.io/falcor/documentation/paths.html). The resulting JSON Graph Envelope is merged together with the function's response:
 
 ~~~js
 {
@@ -996,7 +996,7 @@ Finally the object executing the abstract get operation retrieves each [Path](ht
 ["todos"].concat(["length"]) // produces ["todos", "length"]
 ~~~
 
-The object executing the abstract call operation now executes the abstract get operation to retrieve these newly-created [paths](http://netflix.github.io/falcor/documentation/paths.html). The resulting JSON Graph Envelope is merged together with the function's response:
+The object executing the abstract call operation now executes the abstract get operation to retrieve these newly-created [Paths](http://netflix.github.io/falcor/documentation/paths.html). The resulting JSON Graph Envelope is merged together with the function's response:
 
 ~~~js
 {

--- a/documentation/model.md
+++ b/documentation/model.md
@@ -17,7 +17,7 @@ Your application can use [Data Sources](http://netflix.github.io/falcor/document
 3. In response to user navigation (ex. scrolling through a list), views may need to repeatedly access small quantities of fine-grained data in rapid succession. [Data Sources](http://netflix.github.io/falcor/documentation/datasources.html) typically access the network, therefore fine-grained requests are often inefficient because of the overhead required to issue a request.
 4. Navigating information hierarchically rather than retrieving information using id's can lead to inefficent back-end requests.
 
-For these reasons views retrieve their data from Model objects, which act as intermediaries between the view and the [Data Source](http://netflix.github.io/falcor/documentation/datasources.html). Models abstract over [Data Sources](http://netflix.github.io/falcor/documentation/datasources.html) and provide several important services:
+For these reasons, views retrieve their data from Model objects, which act as intermediaries between the view and the [Data Source](http://netflix.github.io/falcor/documentation/datasources.html). Models abstract over [Data Sources](http://netflix.github.io/falcor/documentation/datasources.html) and provide several important services:
 
 * Models convert [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) information retrieved from the [Data Source](http://netflix.github.io/falcor/documentation/datasources.html) into JSON.
 * Models reduce latency by caching data previously retrieved from the [Data Source](http://netflix.github.io/falcor/documentation/datasources.html) in an in-memory cache.
@@ -89,9 +89,9 @@ There is one very important difference between working with a JSON object direct
 
 ### "Why can't I request Objects or Arrays from a Model?"
 
-_Falcor is optimized for displaying data catered to your views._ Both Arrays and Objects can contain an unbounded amount of data. Requesting an Array or Object in its entirety is equivalent to your view requesting 'SELECT *' without a 'WHERE' clause in the SQL world. An Array that contains 5 items today, can grow to contain 10,000 items later on. This means that requests which are initially served quickly and fit the view's requirements can become slower over time as more data is added to backend data stores.
+_Falcor is optimized for displaying data catered to your views._ Both Arrays and Objects can contain an unbounded amount of data. Requesting an Array or Object in its entirety is equivalent to your view requesting `SELECT *` without a `WHERE` clause in the SQL world. An Array that contains 5 items today, can grow to contain 10,000 items later on. This means that requests which are initially served quickly and fit the view's requirements can become slower over time as more data is added to backend data stores.
 
-Models force developers to be explicit about which value types they would like to retrieve in order to maximize the likelihood that server requests will have **stable performance** over time. Rather than allow you to retrieve an entire Object, Models force you to _be explicit_ and retrieve only those values needed in a given scenario. Similarly when displaying an Array of items, Models do not allow you to retrieve the entire Array upfront. Instead you must request the first visible page of an Array, and follow up with additional page requests as the user scrolls. This allows your client code to control performance boundaries, based on the amount of data actually used in the view, as opposed to being susceptible to unexpected increases in the total amount of data available.
+Models force developers to be explicit about which value types they would like to retrieve in order to maximize the likelihood that server requests will have **stable performance** over time. Rather than allow you to retrieve an entire Object, Models force you to _be explicit_ and retrieve only those values needed in a given scenario. Similarly, when displaying an Array of items, Models do not allow you to retrieve the entire Array upfront. Instead you must request the first visible page of an Array, and follow up with additional page requests as the user scrolls. This allows your client code to control performance boundaries, based on the amount of data actually used in the view, as opposed to being susceptible to unexpected increases in the total amount of data available.
 
 In the following example we page through a list of TODOs, selecting the "name" and "done" properties of all the TODOs in the current page.
 
@@ -807,16 +807,16 @@ To understand how the deref method is used, let's take a look at an example. Ima
 ~~~js
   {
     list: [
-      { $type: “ref”, value: [“titlesById”, 53] },
-      { $type: “ref”, value: [“titlesById”, 67] }
+      { $type: "ref", value: ["titlesById", 53] },
+      { $type: "ref", value: ["titlesById", 67] }
     ],
     titlesById: {
       53: {
-        name: “House of Cards”,
+        name: "House of Cards",
         rating: 5.0
       },
       67: {
-        name: “Daredevil”,
+        name: "Daredevil",
         rating: 5.0
       } 
     }
@@ -830,7 +830,7 @@ To display the information, we can create a list view which accepts a Model and 
 When an item is selected, the List view could pass the Model to the Detail view, along with the path to the selected item.
 
 ~~~js
-new DetailView(model, [“list”, selectedIndex]);
+new DetailView(model, ["list", selectedIndex]);
 ~~~
 
 This is an anti-pattern because the path contains the index in the list where the title is located, and this item may shift in the list between the time the object is displayed and the user drills down and selects it. 
@@ -839,18 +839,18 @@ Instead of passing paths around, the List view can pass a Model dereferenced to 
 
 ~~~js
 function item_selected(selectedIndex) {
-  // response was previous retrieved using model.get(“list[0..1].name”)
+  // response was previous retrieved using model.get("list[0..1].name")
   if (response.json.list && response.json.list[selectedIndex]) {
     new DetailView(model.deref(json.list[selectedIndex]));
   }
 }
 ~~~
 
-In this example, when a user clicks on a title we dereference a Model against the title object we retrieved earlier. We pass the dereferenced Model to the Detail view which can use it to retrieve more information from the title.
+In this example, when a user clicks on a title, we dereference a Model against the title object we retrieved earlier. We pass the dereferenced Model to the Detail view which can use it to retrieve more information from the title.
 
 ~~~js
 function DetailView(titleModel) {
-  titleModel.getValue(“rating”).then(function(rating) {
+  titleModel.getValue("rating").then(function(rating) {
     // display rating
   });
 }
@@ -858,33 +858,33 @@ function DetailView(titleModel) {
 
 Operations performed on the dereferenced Model will always be applied to the same object, no matter where the object is moved within the graph. Furthermore code can interact with the object without any knowledge of its location within the graph.
 
-Deref uses metadata that the get operation inserts information about the references it encounters into JSON responses. For example, retrieving “list[0].name” will yield the following JSON response.
+Deref uses metadata that the get operation inserts information about the references it encounters into JSON responses. For example, retrieving "list[0].name" will yield the following JSON response.
 
 ~~~js
 {
   json: {
     list: {
      0: {
-       $__: [“titlesById”, 53],
-       name: “House of Cards”
+       $__: ["titlesById", 53],
+       name: "House of Cards"
       }
     }
   }
 }
 ~~~
 
-Note the “$__path” added to the JSON response. When you dereference an object within a Falcor response, the new Model internally stores this path. Note that you should not use these metadata properties directly, as the specific property name may change over time and is an implementation detail. Rather you should use the public deref method instead.
+Note the "$__path" added to the JSON response. When you dereference an object within a Falcor response, the new Model internally stores this path. Note that you should not use these metadata properties directly, as the specific property name may change over time and is an implementation detail. Rather you should use the public deref method instead.
 
 ### Passing Dereferenced Models to Call
 
 Dereferenced models can be passed as the argument to a function invoked with call. This approach allows you to pass an object to a function by identity, rather than a path to a volatile location within the graph.
 
 ~~~js
-var model = new falcor.Model(new HttpDataSource(“/model.json”));
-model.get(“list[0]”).then(response => {
+var model = new falcor.Model(new HttpDataSource("/model.json"));
+model.get("list[0]").then(response => {
   var titleModel = model.deref(response.json.list[0]);
   return model.
-    call(“myList.push”, [titleModel], [], [“length”]).
+    call("myList.push", [titleModel], [], ["length"]).
     then(response => console.log(response.json.myList.length));
 });
 ~~~  
@@ -892,11 +892,11 @@ model.get(“list[0]”).then(response => {
 The code above works because JSON stringifying a dereferenced Model produces a JSON Graph reference that points to the object in the Graph. 
 
 ~~~js
-var model = new falcor.Model(new HttpDataSource(“/model.json”));
-model.get(“list[0]”).then(response => {
+var model = new falcor.Model(new HttpDataSource("/model.json"));
+model.get("list[0]").then(response => {
   var titleModel = model.deref(response.json.list[0]);
   console.log(JSON.stringify(titleModel)); 
-  // prints { $type: “ref”, value: [“titlesById”, 53] }
+  // prints { $type: "ref", value: ["titlesById", 53] }
 });
 ~~~
 

--- a/documentation/paths.md
+++ b/documentation/paths.md
@@ -73,7 +73,7 @@ In addition to Path Syntax Strings, [Models](http://netflix.github.io/falcor/doc
 * ["todos", 5, true]
 * ["todos", 9, null]
 
-Using a Path Array is more efficient than the Path Syntax, because under the hood a [Model](http://netflix.github.io/falcor/documentation/model.html) immediately parses Path Syntax Strings into Path Arrays. Furthermore a Path Array is often preferable when you have to build Paths programmatically, because string concatenation can be avoided.
+Using a Path Array is more efficient than the Path Syntax, because under the hood a [Model](http://netflix.github.io/falcor/documentation/model.html) immediately parses Path Syntax Strings into Path Arrays. Furthermore, a Path Array is often preferable when you have to build Paths programmatically, because string concatenation can be avoided.
 
 ~~~js
 // Path Syntax String
@@ -110,7 +110,7 @@ model.
 
 ## PathSets
 
-A PathSet is a human-readable short-hand for a set of Paths. Any [Models](http://netflix.github.io/falcor/documentation/model.html) method which can accept multiple Paths, can also accept multiple PathSets.
+A PathSet is a human-readable shorthand for a set of Paths. Any [Model](http://netflix.github.io/falcor/documentation/model.html) method which can accept multiple Paths, can also accept multiple PathSets.
 
 In other words of writing this...
 
@@ -154,7 +154,7 @@ The following PathSet Strings are valid:
 * "todos[0...2].name" is equivalent to "todos[0].name", and "todos[1].name"
 * "todos[0..1]['name','done']" is equivalent to "todos[0].name", "todos[0].done", "todos[1].name", and "todos[1].done"
 * 'todos[0..1]["name","done"]' is equivalent to "todos[0].name", "todos[0].done", "todos[1].name", and "todos[1].done"
-* "todos[0..1, "length"] is equivalent to "todos[0]", "todos[1]", and "todos.length"
+* "todos[0..1, 'length']" is equivalent to "todos[0]", "todos[1]", and "todos.length"
 
 ### PathSet Array
 

--- a/documentation/router.md
+++ b/documentation/router.md
@@ -10,7 +10,7 @@ lang: en
 
 # The Falcor Router
 
-A Falcor Router is an implementation of the [DataSource](http://netflix.github.io/falcor/documentation/datasources.html) interface. Falcor [Model](http://netflix.github.io/falcor/documentation/model.html) objects use [DataSource](http://netflix.github.io/falcor/documentation/datasources.html)s to retrieve [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) data. However [Model](http://netflix.github.io/falcor/documentation/model.html)s typically run on the client and Routers typically run on the Application server. As a result communication between a [Model](http://netflix.github.io/falcor/documentation/model.html) and the Router is typically remoted across the network using an HttpDataSource.
+A Falcor Router is an implementation of the [DataSource](http://netflix.github.io/falcor/documentation/datasources.html) interface. Falcor [Model](http://netflix.github.io/falcor/documentation/model.html) objects use [DataSource](http://netflix.github.io/falcor/documentation/datasources.html)s to retrieve [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) data. However [Model](http://netflix.github.io/falcor/documentation/model.html)s typically run on the client and Routers typically run on the Application server. As a result, communication between a [Model](http://netflix.github.io/falcor/documentation/model.html) and the Router is typically remoted across the network using an HttpDataSource.
 
 ![Falcor End to End](../images/falcor-end-to-end.png)
 
@@ -20,9 +20,9 @@ In order to create the requested subset of the [JSON Graph](http://netflix.githu
 
 ## When to use a Router
 
-The Router is appropriate as an abstraction over a service layer or REST API. Using a Router over these types of APIs provides just enough flexibility to avoid client round-trips without introducing heavy-weight abstractions. Service-oriented architectures are common in systems that are designed for scalability. These systems typically store data in different data sources and expose them through a variety of different services. For example Netflix uses a Router in front of its [Microservice architecture](http://techblog.netflix.com/2015/02/a-microscope-on-microservices.html). 
+The Router is appropriate as an abstraction over a service layer or REST API. Using a Router over these types of APIs provides just enough flexibility to avoid client round-trips without introducing heavy-weight abstractions. Service-oriented architectures are common in systems that are designed for scalability. These systems typically store data in different data sources and expose them through a variety of different services. For example, Netflix uses a Router in front of its [Microservice architecture](http://techblog.netflix.com/2015/02/a-microscope-on-microservices.html). 
 
-**It is rarely ideal to use a Router to directly access a single SQL Database**. Application's that use a single SQL store often attempt to build one SQL Query for every server request. Routers work by splitting up requests for different sections of the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) into separate handlers and sending individual requests to services to retrieve the requested data. As a consequence, invidual Router handlers rarely have sufficient context to produce a single optimized SQL query. We are currently exploring different options for supporting this type of data access pattern with Falcor in future.
+**It is rarely ideal to use a Router to directly access a single SQL Database**. Applications that use a single SQL store often attempt to build one SQL Query for every server request. Routers work by splitting up requests for different sections of the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) into separate handlers and sending individual requests to services to retrieve the requested data. As a consequence, individual Router handlers rarely have sufficient context to produce a single optimized SQL query. We are currently exploring different options for supporting this type of data access pattern with Falcor in future.
 
 ## Contrasting a REST Router with a Falcor Router 
 
@@ -66,7 +66,7 @@ var router = new Router([
 
 ### 2. A Single Falcor Route Can Match Multiple Paths
 
-Traditional App server Routers only need to match the URL path, because HTTP requests are designed to retrieve a single resource. In contrast a single HTTP request to a Falcor application server may contain multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) in the query string. As a result a single Falcor route can match multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) at once. Matching multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) in a single route can be more efficient in the event they can be retrieved with a single backend request.
+Traditional App server Routers only need to match the URL path, because HTTP requests are designed to retrieve a single resource. In contrast, a single HTTP request to a Falcor application server may contain multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) in the query string. As a result, a single Falcor route can match multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) at once. Matching multiple [paths](http://netflix.github.io/falcor/documentation/paths.html) in a single route can be more efficient in the event they can be retrieved with a single backend request.
 
 The following request attempts to retrieve the name and length of the todos list:
 
@@ -120,7 +120,7 @@ The Router accepts all of these path/value pairs, adds them to a single JSON obj
 
 In addition to allowing multiple values to be retrieved in a single request, Falcor routers can also traverse entity relationships and retrieve related values within the same request.
 
-REST APIs often expose different kinds of resources at different end points. These resources often contain hyperlinks to related resources. For example the following endpoint /todos returns a JSON array of hyperlinks to task resources:
+REST APIs often expose different kinds of resources at different endpoints. These resources often contain hyperlinks to related resources. For example the following endpoint /todos returns a JSON array of hyperlinks to task resources:
 
 ~~~js
 [
@@ -217,7 +217,7 @@ var TODORouter = function(userId){
 TODORouter.prototype = Object.create(BaseRouter.prototype);
 ~~~
 
-The next version of JavaScript (ES2015) has native support for classes. If you are using a version of node that supports classes, or you are using a transpiler, you can write this code instead of the code seen above:
+The next version of JavaScript (ES2015) has native support for classes. If you are using a version of Node that supports classes, or you are using a transpiler, you can write this code instead of the code seen above:
 
 ~~~js
 var Router = require("falcor-router");
@@ -557,7 +557,7 @@ titlesById[{integers}].name
 ["titlesById", [234,223,555,111,112,113],"name"]
 ~~~
 
-This pattern is most often when matching entities by an integer ID. For example, the following route builds a map of all tasks by ID.
+This pattern is used most often when matching entities by an integer ID. For example, the following route builds a map of all tasks by ID.
 
 ~~~js
 var jsong = require('falcor-json-graph');
@@ -628,7 +628,7 @@ genreList[{ranges}].name
 ["genreList", [{from:0,to:1}, {from:5,to:7}, {from:9,to:9}], "name"]
 ~~~
 
-The {ranges} pattern is most often when matching indices in a list. It is ideal when the underlying service API supports paging. For example the following route retrieves the names of Netflix genre lists:
+The {ranges} pattern is used most often when matching indices in a list. It is ideal when the underlying service API supports paging. For example the following route retrieves the names of Netflix genre lists:
 
 ~~~js
 var jsong = require('falcor-json-graph');
@@ -693,7 +693,7 @@ genreList[{keys}]
 ["genreList", [0, 2, 3, 4, "length"]]
 ~~~
 
-This pattern is most often when matching entities by a GUID. For example, the following route builds a map of all titles by GUID.
+This pattern is used most often when matching entities by a GUID. For example, the following route builds a map of all titles by GUID.
 
 ~~~js
 var jsong = require('falcor-json-graph');
@@ -753,7 +753,7 @@ Netflix is an online streaming video service with millions of subscribers.  When
 
 ![Netflix Homepage](http://netflix.github.io/falcor/images/netflix-screenshot.png)
 
-In this exercise we will build a Router for an application similar to Netflix, which merchandises titles to members based on their preferences, and allows them to provide user ratings for each title. This exercise is purely a demonstration of how to build a Router for a web application that displays a catalog of information to a user. This is **not** intended to demonstrate how to Netflix actually works, and any similarities to the actual Netflix Router's implementation are superficial. The entire source for this guide is [online](https://github.com/netflix/falcor-router-demo).
+In this exercise, we will build a Router for an application similar to Netflix, which merchandises titles to members based on their preferences, and allows them to provide user ratings for each title. This exercise is purely a demonstration of how to build a Router for a web application that displays a catalog of information to a user. This is **not** intended to demonstrate how to Netflix actually works, and any similarities to the actual Netflix Router's implementation are superficial. The entire source for this guide is [online](https://github.com/netflix/falcor-router-demo).
 
 Our goal is to define a [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) resource on the Application server that exposes all of the data that our Netflix clone needs. The [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) schema should be designed in such a way that the application can retrieve all of the data it needs for any given application scenario in a single network request.
 
@@ -931,7 +931,7 @@ Given the advantages of matching multiple [paths](http://netflix.github.io/falco
 "genrelist[{integers}].titles[{integers}]"
 ~~~
 
-However it doesn't always make sense to create routes that match as many [paths](http://netflix.github.io/falcor/documentation/paths.html) as possible. Note that the title's "rating" and "userRating" keys are retrieved from the RatingService, while all of the other title keys are retrieved from the TitleService. As a result creating a single route which matches both the "name" and "rating" of a title wouldn't be useful, because serving each individual key would require a request to an entirely different service. Furthermore the code to create each of these values would be very different. Under the circumstances there is little to be gained by handling both these [paths](http://netflix.github.io/falcor/documentation/paths.html) in a single route.
+However it doesn't always make sense to create routes that match as many [paths](http://netflix.github.io/falcor/documentation/paths.html) as possible. Note that the title's "rating" and "userRating" keys are retrieved from the RatingService, while all of the other title keys are retrieved from the TitleService. As a result, creating a single route which matches both the "name" and "rating" of a title wouldn't be useful, because serving each individual key would require a request to an entirely different service. Furthermore the code to create each of these values would be very different. Under the circumstances there is little to be gained by handling both these [paths](http://netflix.github.io/falcor/documentation/paths.html) in a single route.
 
 A better strategy than creating routes which match as many [paths](http://netflix.github.io/falcor/documentation/paths.html) as possible is to create routes that match [paths](http://netflix.github.io/falcor/documentation/paths.html) that are retrieved from the same service. The code to retrieve values stored in the same service is likely to be similar, and more importantly it may provide us with opportunities to make a single service call to retrieve multiple values.
 
@@ -950,7 +950,7 @@ Note that although the genre list routes all retrieve their data from the recomm
 
 ## Handling Authorization
 
-Now that we have chosen our routes we need to consider whether our route handlers have sufficient information to handle requests. Note that _many of the routes in the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object are personalized for the current user_. For example, two different Netflix users will likely see completely different personalized recommendations in their "genrelist" arrays. The "rating" and "userRating" fields are also specific to the current user. The "rating" field is the algorithmically-predicted rating for the user based on the user's previous viewing history and user-specified ratings. The "userRating" field is the user–specified rating for the title, and it should not be possible to set this value if a user is not logged in.
+Now that we have chosen our routes, we need to consider whether our route handlers have sufficient information to handle requests. Note that _many of the routes in the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object are personalized for the current user_. For example, two different Netflix users will likely see completely different personalized recommendations in their "genrelist" arrays. The "rating" and "userRating" fields are also specific to the current user. The "rating" field is the algorithmically-predicted rating for the user based on the user's previous viewing history and user-specified ratings. The "userRating" field is the user–specified rating for the title, and it should not be possible to set this value if a user is not logged in.
 
 While a login is clearly required to change data or receive personalized recommendations, we would like to be able to use to allow users to browse the catalog without logging in. That's why both the recommendations service and rating service fallback to providing generic recommendations and ratings in the absence of a user ID.
 
@@ -1020,7 +1020,7 @@ We will create this map using two different routes:
 "titlesById[{integers}]['rating', 'userRating']
 ~~~
 
-The first route will retrieve it's information from the title service, which is a repository of non-personalized title metadata. The second route will retrieve its information from the rating service, which provides personalized ratings based on the users past preferences.
+The first route will retrieve its information from the title service, which is a repository of non-personalized title metadata. The second route will retrieve its information from the rating service, which provides personalized ratings based on the users past preferences.
 
 Let's start with the first route, because it does not require any user authentication:
 
@@ -1388,7 +1388,7 @@ Now that we understand how the rating service works, let's create a route that m
     }
 ~~~
 
-Each one of the Routers route handlers runs with the Router instance as it's "this" object. That means that our route handler has access to the Router's userId member. The handler passes the Router's userId to the recommendation service, which retrieves a personalized genre list for the current user. If the current user is not authenticated, the Router's userId will be undefined. If an undefined userId is passed to the rating service, the service simply returns a record with a generic "rating" and no "userRating" key.
+Each one of the Routers route handlers runs with the Router instance as its "this" object. That means that our route handler has access to the Router's userId member. The handler passes the Router's userId to the recommendation service, which retrieves a personalized genre list for the current user. If the current user is not authenticated, the Router's userId will be undefined. If an undefined userId is passed to the rating service, the service simply returns a record with a generic "rating" and no "userRating" key.
 
 Now we should be able to retrieve any title field by ID.
 
@@ -1418,7 +1418,7 @@ The request above matches both routes we have created. The Router adds the resul
 
 Note how the router presents the consumer with what appears to be a single title object, but sources the data for the title from multiple services. The result is a simple API for the consumer without compromising any flexibility about where data is stored on the backend.
 
-Now we have the ability to retrieve information about any title in the catalog using that ID. However in practice our users will not be navigating titles by ID. When a user starts the application, they will be presented with a list of genres, each of which contains a list of recommended titles. Users will navigate through these titles positionally, scrolling vertically and horizontally. As a consequence the application needs to be able to retrieve titles by position within the user's personalized recommendations list. To accommodate this requirement, we will add the users genre list to the Router's virtual [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object.
+Now we have the ability to retrieve information about any title in the catalog using that ID. However in practice our users will not be navigating titles by ID. When a user starts the application, they will be presented with a list of genres, each of which contains a list of recommended titles. Users will navigate through these titles positionally, scrolling vertically and horizontally. As a consequence, the application needs to be able to retrieve titles by position within the user's personalized recommendations list. To accommodate this requirement, we will add the user's genre list to the Router's virtual [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object.
 
 ### Creating the Genre List Routes
 
@@ -1632,7 +1632,7 @@ Now let's tackle the most challenging of all of the genre list routes...
 
 #### The "genrelist[{integers}].titles[{integers}]" Route
 
-This route builds the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) references in the titles array within each genre. In other words this route will create this portion of the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object:
+This route builds the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) references in the titles array within each genre. In other words, this route will create this portion of the [JSON Graph](http://netflix.github.io/falcor/documentation/jsongraph.html) object:
 
 ~~~js
 {

--- a/starter/getting-started.md
+++ b/starter/getting-started.md
@@ -11,7 +11,7 @@ In this barebones tutorial we will use the falcor Router to create a Virtual JSO
 
 ## Creating a Virtual JSON Resource
 
-In this example we will use the falcor Router to build a Virtual JSON resource on an app server. The and host it at /model.json. The JSON resource will contain the following contents:
+In this example we will use the falcor Router to build a Virtual JSON resource on an app server. We'll host it at /model.json. The JSON resource will contain the following contents:
 
 ~~~js
 {
@@ -19,7 +19,7 @@ In this example we will use the falcor Router to build a Virtual JSON resource o
 }
 ~~~
 
-Normally Routers retrieve the data for their Virtual JSON resource from backend datastores or other web services on-demand. However in this simple tutorial the Router will simply return static data for a single key.
+Normally Routers retrieve the data for their Virtual JSON resource from backend datastores or other web services on-demand. However, in this simple tutorial, the Router will simply return static data for a single key.
 
 First we create a folder for our application server.
 

--- a/starter/how-does-falcor-work.md
+++ b/starter/how-does-falcor-work.md
@@ -11,11 +11,11 @@ The Falcor Model transparently handles all network communication with the server
 
 ## Caching
 
-Falcor maintains a fast in–memory cache that contains all of the values previously retrieved from the application server's JSON object. If a request is made for information that is already available in the cache, the data will be retrieved from the cache and sent to the consumers callback as soon as possible.
+Falcor maintains a fast in–memory cache that contains all of the values previously retrieved from the application server's JSON object. If a request is made for information that is already available in the cache, the data will be retrieved from the cache and sent to the consumer's callback as soon as possible.
 
 ![Model caching](../images/model-caching.png)
 
-To avoid allowing the cache to grow larger than the available memory on the device, developers can configure a maximum size for the cache. When the cache grows beyond the maximum size, the least-recently-used values are purged. This makes it possible to run the same application on an inexpensive mobile device or a powerful desktop machine.
+To prevent the cache growing larger than the available memory on the device, developers can configure a maximum size for the cache. When the cache grows beyond the maximum size, the least-recently-used values are purged. This makes it possible to run the same application on an inexpensive mobile device or a powerful desktop machine.
 
 ## Batching
 

--- a/starter/video-tutorials.md
+++ b/starter/video-tutorials.md
@@ -18,7 +18,7 @@ In addition to being able to retrieve a path from a Falcor Model, you can also r
 
 ### 3. [Intro to JSON Graph](https://www.youtube.com/watch?v=2xX5JTHWw4Q)
 
-JSON is a very commonly used data interchange format. Unfortunately while most application domain models are graphs, JSON is designed to model hierarchical information. To get around this problem, Falcor introduces JSON Graph. JSON Graph introduces references to JSON, allowing you to ensure that no object appears more than once in your JSON.
+JSON is a very commonly-used data interchange format. Unfortunately, while most application domain models are graphs, JSON is designed to model hierarchical information. To get around this problem, Falcor introduces JSON Graph. JSON Graph introduces references to JSON, allowing you to ensure that no object appears more than once in your JSON.
 
 ### 4. [Building Paths Programmatically](https://www.youtube.com/watch?v=XyMHk4wKg3Q)
 
@@ -26,15 +26,15 @@ In this video you will learn how to build Paths and Path Sets programmatically u
 
 ### 5. [JSON Graph in-depth](https://www.youtube.com/watch?v=9tAvnn-Wd14)
 
-In this video you will learn why it is only possible to retrieve value types from a Falcor Model. The prohibition against retrieving Objects or Arrays from your JSON object leads to more predicable server performance, because server requests stay approximately the same speed despite the growth of your backend data set.
+In this video you will learn why it is only possible to retrieve value types from a Falcor Model. The prohibition against retrieving Objects or Arrays from your JSON object leads to more predicable server performance, because server requests stay approximately the same speed despite the growth of your backend dataset.
 
 ### 6. [Retrieving Data from the Server](http://youtu.be/dlcqUcjR1Ig)
 
-In this video you will learn how to retrieve data from an Node application server running express. You'll also learn about the DataSource interface, and how Models use DataSources to retrieve JSON data.
+In this video you will learn how to retrieve data from a Node application server running express. You'll also learn about the DataSource interface, and how Models use DataSources to retrieve JSON data.
 
 ### 7. [Path Optimization](https://www.youtube.com/watch?v=PlG55w_G9mw)
 
-One of the most powerful optimizations Falcor makes when requesting data from the server is Path Optimization. When patterns are requested from the model, the model checks it's local cache first, and if the value is not present, requests the data from its data source (usually the server). However if references are encountered while evaluating the path against the cache, the Model uses them to optimize the path before forwarding the path request to the data source. By providing optimized paths to the server Falcor can reduce the cost of retrieving data from your persistent data stores.
+One of the most powerful optimizations Falcor makes when requesting data from the server is Path Optimization. When patterns are requested from the model, the model checks its local cache first, and if the value is not present, requests the data from its data source (usually the server). However, if references are encountered while evaluating the path against the cache, the Model uses them to optimize the path before forwarding the path request to the data source. By providing optimized paths to the server, Falcor can reduce the cost of retrieving data from your persistent data stores.
 
 ### 8. [Batching Requests](https://www.youtube.com/watch?v=ulK8m8_HGJg)
 

--- a/starter/what-is-falcor.md
+++ b/starter/what-is-falcor.md
@@ -17,7 +17,7 @@ Falcor allows you to model all of your backend data as a single JSON resource on
 
 ![Model all your backend data as one JSON resource](../documentation/network-diagram.png)
 
-Clients request subsets of this JSON resource on demand, just like they would from an in-memory JSON object. To retrieve values from the JSON resource on the server the client passes the server JavaScript paths to each desired value within the JSON object. The server responds with a subset of the JSON object that contains only those values.
+Clients request subsets of this JSON resource on demand, just like they would from an in-memory JSON object. To retrieve values from the JSON resource on the server, the client passes the server JavaScript paths to each desired value within the JSON object. The server responds with a subset of the JSON object that contains only those values.
 
 ~~~
 /model.json?paths=["user.name", "user.surname", "user.address"]
@@ -68,9 +68,9 @@ The Falcor Router allows you to expose a single JSON model to the client, while 
 
 ## The Data is the API
 
-You do not need to learn a complicated service layer to work with your data when you are using Falcor. If you know your data, you know your API. Falcor allows you to work with remote data the same way you work with local data, using JavaScript paths and operations. The primary difference is that Falcor’s client API is asynchronous.
+You do not need to learn a complicated service layer to work with your data when you are using Falcor. If you know your data, you know your API. Falcor allows you to work with remote data the same way you work with local data, using JavaScript paths and operations. The primary difference is that Falcor's client API is asynchronous.
 
-Here’s an example retrieving the surname of a user directly from an in-memory JSON object using a simple JavaScript path.
+Here's an example retrieving the surname of a user directly from an in-memory JSON object using a simple JavaScript path.
 
 ~~~js
 var model = {
@@ -81,13 +81,13 @@ var model = {
   }
 };
 
-// prints “Underwood”
+// prints "Underwood"
 console.log(model.user.surname);
 ~~~
 
 Applications that use Falcor do not work directly with JSON data. Instead they work with their JSON data indirectly using a Falcor Model. The Falcor Model allows you to use familiar idioms like JavaScript paths and JavaScript operations to work with your data. The primary difference between working with JSON data directly and using a Falcor Model, is that a Falcor Model has an asynchronous API.
 
-Let’s rewrite the code above using a Falcor Model instead of working with the JSON directly:
+Let's rewrite the code above using a Falcor Model instead of working with the JSON directly:
 
 ~~~js
 var model = new falcor.Model({
@@ -100,9 +100,9 @@ var model = new falcor.Model({
   }
 });
 
-// prints “Underwood” eventually
+// prints "Underwood" eventually
 model.
-  getValue(“user.surname”).
+  getValue("user.surname").
   then(function(surname) {
     console.log(surname);
   });
@@ -110,26 +110,26 @@ model.
 
 Note that we use the same JavaScript path to retrieve our data as when we worked with the JSON data directly. The only difference is that the result is pushed to a callback when it becomes available.
 
-The advantage of working with your data using Falcor’s asynchronous API is that you can move your data anywhere on the network without changing the client code that consumes the data. Using the Falcor Model, we only need to change a few lines of code to alter the previous example to work with remote data.
+The advantage of working with your data using Falcor's asynchronous API is that you can move your data anywhere on the network without changing the client code that consumes the data. Using the Falcor Model, we only need to change a few lines of code to alter the previous example to work with remote data.
 
 ~~~js
 var model = new falcor.Model({
-  source: new falcor.HttpDataSource(“/model.json”)
+  source: new falcor.HttpDataSource("/model.json")
 });
 
-// prints “Underwood” eventually
+// prints "Underwood" eventually
 model.
-  getValue(“user.surname”).
+  getValue("user.surname").
   then(function(surname) {
     console.log(surname);
   });
 ~~~
 
-Now instead of working with in-memory JSON data, Falcor remotes requests for data to the application server’s Virtual JSON object. The Router retrieve the data from the data store with the information, and sends back only the requested fields.
+Now instead of working with in-memory JSON data, Falcor remotes requests for data to the application server's Virtual JSON object. The Router retrieves the data from the data store with the information, and sends back only the requested fields.
 
 ![Falcor end-to-end](../images/falcor-end-to-end.png)
 
-Using an asynchronous API allows you to use the same programming model regardless of whether your data is local or remote. With Falcor it is common practice to begin development immediately by mocking the server’s JSON object. Once the server’s JSON resource has been written, the Falcor Model is connected to the server JSON using an HttpDataSource. No other client code needs to change. This approach can shrink project timelines by decoupling client and server developers.
+Using an asynchronous API allows you to use the same programming model regardless of whether your data is local or remote. With Falcor it is common practice to begin development immediately by mocking the server's JSON object. Once the server's JSON resource has been written, the Falcor Model is connected to the server JSON using an HttpDataSource. No other client code needs to change. This approach can shrink project timelines by decoupling client and server developers.
 
 ## Bind to the Cloud
 
@@ -137,6 +137,6 @@ In most MVC systems, controllers are responsible for retrieving data from the se
 
 ![Async MVC](../images/async-mvc.png)
 
-In addition to decoupling controllers and views Async MVC can improve the efficiency of your application’s network requests. When the view drives the data fetching, only the data absolutely required to render a view is retrieved from the server.
+In addition to decoupling controllers and views, Async MVC can improve the efficiency of your application's network requests. When the view drives the data fetching, only the data absolutely required to render a view is retrieved from the server.
 
 In addition to **Async MVC** there are a variety of different patterns for integrating Falcor into your application. We are looking to the community for help building adapters for the various frameworks in use today.


### PR DESCRIPTION
Besides standard English changes, I did the following:

* Replaced all "smart quotes" (`“` and `”`) with dumb quotes (`"`). In places where smart quotes were used in text, they were often wrong (two left-hand quotes or two right-hand quotes). Where they were used in code snippets, they resulted in invalid code. Jekyll converts dumb quotes to smart ones automatically anyway (ignoring code snippets).
* Replaced a bunch of instances of "JSON stringify algorithm" with "JavaScript's toString algorithm". This was already correct on the "Paths" page, but was consistently incorrect on the "JSON Graph" page. I think "JSON stringify algorithm" means `JSON.stringify` which is a way to turn a JavaScript Array or Object into a JSON string. "JavaScript's toString algorithm" is just calling `.toString` on something, like `(4).toString()`