### PR TITLE
0.x change for removing boxValues from asDataSource().

### DIFF
--- a/lib/ModelDataSourceAdapter.js
+++ b/lib/ModelDataSourceAdapter.js
@@ -1,5 +1,5 @@
 function ModelDataSourceAdapter(model) {
-    this._model = model._materialize().boxValues().treatErrorsAsValues();
+    this._model = model._materialize().treatErrorsAsValues();
 }
 
 ModelDataSourceAdapter.prototype.get = function get(pathSets) {

--- a/test/falcor/get/get.model.adapter.spec.js
+++ b/test/falcor/get/get.model.adapter.spec.js
@@ -1,0 +1,32 @@
+var falcor = require("./../../../lib/");
+var Model = falcor.Model;
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var chai = require('chai');
+var expect = chai.expect;
+var noOp = function() {};
+
+describe('ModelDataSourceAdapter', function() {
+    it('ensure atoms remain as strings if model created.', function(done) {
+        var model = new Model({
+            cache: {
+                hello: 'world'
+            }
+        });
+
+        var onNext = sinon.spy();
+        model.
+            asDataSource().
+            get([['hello']]).
+            doAction(onNext, noOp, function() {
+                expect(onNext.callCount).to.equals(1);
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        hello: 'world'
+                    },
+                    paths: [['hello']]
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+});

--- a/test/falcor/get/get.model.adapter.spec.js
+++ b/test/falcor/get/get.model.adapter.spec.js
@@ -5,6 +5,7 @@ var sinon = require('sinon');
 var chai = require('chai');
 var expect = chai.expect;
 var noOp = function() {};
+var toObs = require('./../../toObs');
 
 describe('ModelDataSourceAdapter', function() {
     it('ensure atoms remain as strings if model created.', function(done) {
@@ -15,9 +16,9 @@ describe('ModelDataSourceAdapter', function() {
         });
 
         var onNext = sinon.spy();
-        model.
+        toObs(model.
             asDataSource().
-            get([['hello']]).
+            get([['hello']])).
             doAction(onNext, noOp, function() {
                 expect(onNext.callCount).to.equals(1);
                 expect(onNext.getCall(0).args[0]).to.deep.equals({

--- a/test/falcor/get/index.js
+++ b/test/falcor/get/index.js
@@ -7,4 +7,5 @@ describe('Get', function() {
     require('./get.pathSyntax.spec');
     require('./get.clone.spec');
     require('./get.gen.spec');
+    require('./get.model.adapter.spec');
 });


### PR DESCRIPTION
toDataSource should use _jsonGraph() as output which properly does boxValues when needed.
