### PR TITLE
Avoid npm no license field warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "type": "git",
     "url": "https://github.com/Netflix/falcor.git"
   },
-  "licenses": [
-    {
-      "type": "Apache License, Version 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "scripts": {
     "test": "gulp test-coverage",
     "dist": "gulp all",


### PR DESCRIPTION
> Some old packages used license objects or a "licenses" property containing an array of license objects [...] Those styles are now deprecated. Instead, use SPDX expressions

https://docs.npmjs.com/files/package.json#license