### PR TITLE
Avoid mutating the previous result object during progressive get.

### DIFF
--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -2,11 +2,34 @@ var getCachePosition = require("./../get/getCachePosition");
 var InvalidModelError = require("./../errors/InvalidModelError");
 var BoundJSONGraphModelError = require("./../errors/BoundJSONGraphModelError");
 
+function mergeInto(target, obj) {
+    /*eslint guard-for-in: 0*/
+    if (target === obj) {
+        return;
+    }
+    if (target === null || typeof target !== "object" || target.$type) {
+        return;
+    }
+    if (obj === null || typeof obj !== "object" || obj.$type) {
+        return;
+    }
+    for (var key in obj) {
+        var targetValue = target[key];
+        if (targetValue === undefined) {
+            target[key] = obj[key];
+        } else {
+            mergeInto(targetValue, obj[key]);
+        }
+    }
+}
+
 module.exports = function get(walk, isJSONG) {
     return function innerGet(model, paths, seed) {
-        var valueNode = seed[0];
+        // Result valueNode not immutable for isJSONG.
+        var nextSeed = isJSONG ? seed : [{}];
+        var valueNode = nextSeed[0];
         var results = {
-            values: seed,
+            values: nextSeed,
             optimizedPaths: []
         };
         var cache = model._root.cache;
@@ -58,6 +81,9 @@ module.exports = function get(walk, isJSONG) {
                  valueNode, results, derefInfo, requestedPath, optimizedPath,
                  optimizedLength, isJSONG, false, referenceContainer);
         }
+
+        // Merge in existing results.
+        mergeInto(valueNode, seed[0]);
 
         return results;
     };

--- a/lib/response/get/GetResponse.js
+++ b/lib/response/get/GetResponse.js
@@ -77,5 +77,5 @@ GetResponse.prototype._subscribe = function _subscribe(observer) {
 
     // Starts the async request cycle.
     return getRequestCycle(this, model, results,
-                           observer, seed, errors, 1);
+                           observer, errors, 1);
 };

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -38,11 +38,12 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
 
     // We are done when there are no missing paths or the model does not
     // have a dataSource to continue on fetching from.
+    var valueNode = results.values[0];
     var hasValues = results.hasValue;
     var completed = !results.requestedMissingPaths ||
                     !results.requestedMissingPaths.length ||
                     !model._source;
-    var hasValueOverall = Boolean(seed[0].json || seed[0].jsonGraph);
+    var hasValueOverall = Boolean(valueNode.json || valueNode.jsonGraph);
 
     // Copy the errors into the total errors array.
     if (results.errors) {
@@ -59,10 +60,10 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     // request is progressive
     //
     // 2.  The request if finished and the json key off
-    // the seed has a value.
+    // the valueNode has a value.
     if (hasValues && progressive || hasValueOverall && completed) {
         try {
-            observer.onNext(seed[0]);
+            observer.onNext(valueNode);
         } catch(e) {
             throw e;
         }

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -17,11 +17,10 @@ var InvalidSourceError = require("../../errors/InvalidSourceError");
  * @param {Function} onNext -
  * @param {Function} onError -
  * @param {Function} onCompleted -
- * @param {Object} seedArg - The state of the output
  * @private
  */
 module.exports = function getRequestCycle(getResponse, model, results, observer,
-                                          seed, errors, count) {
+                                          errors, count) {
     // we have exceeded the maximum retry limit.
     if (count === 10) {
         throw new MaxRetryExceededError();
@@ -62,7 +61,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
                                                   observer,
                                                   getResponse.isProgressive,
                                                   getResponse.isJSONGraph,
-                                                  seed, errors);
+                                                  results.values, errors);
 
             // If there are missing paths coming back form checkCacheAndReport
             // the its reported from the core cache check method.
@@ -71,7 +70,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
                 // update the which disposable to use.
                 disposable.currentDisposable =
                     getRequestCycle(getResponse, model, nextResults, observer,
-                                    seed, errors, count + 1);
+                                    errors, count + 1);
             }
 
             // We have finished.  Since we went to the dataSource, we must

--- a/lib/response/set/setRequestCycle.js
+++ b/lib/response/set/setRequestCycle.js
@@ -33,9 +33,12 @@ module.exports = function setRequestCycle(model, observer, groups,
 
     // Progressively output the data from the first set.
     if (isProgressive) {
-        var json = {};
-        getWithPathsAsPathMap(model, requestedPaths, [json]);
-        observer.onNext(json);
+        var results = getWithPathsAsPathMap(model, requestedPaths, [{}]);
+        if (results.criticalError) {
+            observer.onError(results.criticalError);
+            return null;
+        }
+        observer.onNext(results.values[0]);
     }
 
     var currentJSONGraph = getJSONGraph(model, optimizedPaths);

--- a/test/falcor/get/get.dataSource-and-cache.spec.js
+++ b/test/falcor/get/get.dataSource-and-cache.spec.js
@@ -401,6 +401,25 @@ describe('DataSource and Partial Cache', function() {
                 }).
                 subscribe(noOp, done, done);
         });
+
+        it('should get different response objects with multiple trips to the dataSource.', function(done) {
+            var model = new Model({cache: M(), source: new LocalDataSource(Cache())});
+            var revisions = [];
+            toObservable(model.
+                get(['lolomo', 0, 0, 'item', 'title'], ['lolomo', 0, 1, 'item', 'title']).
+                progressively()).
+                doAction(function(x) {
+                    revisions.push(x);
+                }, noOp, function() {
+                    expect(revisions.length).to.equals(2);
+                    expect(revisions[1]).to.not.equal(revisions[0]);
+                    expect(revisions[1].json.lolomo[0]).to.not.equal(revisions[0].json.lolomo[0]);
+                    expect(revisions[1].json.lolomo[0][0]).to.equal(revisions[0].json.lolomo[0][0]);
+
+                }).
+                subscribe(noOp, done, done);
+        });
+
     });
     describe('Error Selector (during merge)', function() {
 

--- a/test/getCoreRunner.js
+++ b/test/getCoreRunner.js
@@ -81,15 +81,16 @@ module.exports = function(testConfig) {
         });
     }
 
+    var valueNode = out.values && out.values[0];
 
     // $size is stripped out of basic core tests.
     // We have to strip out parent as well from the output since it will produce
     // infinite recursion.
-    clean(seed[0], {strip: ['$size']});
+    clean(valueNode, {strip: ['$size']});
     clean(expectedOutput, {strip: ['$size']});
 
     if (expectedOutput) {
-        expect(seed[0]).to.deep.equals(expectedOutput);
+        expect(valueNode).to.deep.equals(expectedOutput);
     }
     if (requestedMissingPaths) {
         expect(out.requestedMissingPaths).to.deep.equals(requestedMissingPaths);


### PR DESCRIPTION
Only for JSON responses, not JSONGraph. Structural sharing of unchanged subobjects.