### PR TITLE
WIP Invalid deref

### DIFF
--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -32,7 +32,7 @@ module.exports = function get(walk, isJSONG) {
 
             // If there was a short, then we 'throw an error' to the outside
             // calling function which will onError the observer.
-            if (currentCachePosition.$type) {
+            if (currentCachePosition === undefined || currentCachePosition.$type) {
                 return {
                     criticalError: new InvalidModelError(boundPath, boundPath)
                 };

--- a/lib/set/setPathMaps.js
+++ b/lib/set/setPathMaps.js
@@ -24,14 +24,22 @@ var NullInPathError = require("./../errors/NullInPathError");
  */
 
 module.exports = function setPathMaps(model, pathMapEnvelopes, x, errorSelector, comparator) {
-
     var modelRoot = model._root;
     var lru = modelRoot;
     var expired = modelRoot.expired;
     var version = incrementVersion();
     var bound = model._path;
     var cache = modelRoot.cache;
-    var node = bound.length ? getBoundValue(model, bound).value : cache;
+    var node;
+    if (bound.length) {
+        var boundValue = getBoundValue(model, bound);
+        if (!boundValue.found) {
+            throw new Error("What to do here?");
+        }
+        node = boundValue.value;
+    } else {
+        node = cache;
+    }
     var parent = node.ツparent || cache;
     var initialVersion = cache.ツversion;
 

--- a/test/falcor/deref/deref.errors.spec.js
+++ b/test/falcor/deref/deref.errors.spec.js
@@ -72,4 +72,16 @@ describe('Error cases', function() {
             });
     });
 
+    it('should not error on an invalidated deref path set.', function() {
+        var model = new Model({cache: {titlesById: {32: {name: "House of Cards"}}}});
+        return model.get(["titlesById", 32, "name"]).
+            then(function(response) {
+                var titleModel = model.deref(response.json.titlesById[32]);
+                model.invalidate(["titlesById", 32]);
+                return titleModel.set({json: {name: "Something Else"}}).
+                    then(function(derefedResponse) {
+                        expect(response.json.name).to.be("Something Else");
+                    });
+            });
+    });
 });

--- a/test/falcor/deref/deref.errors.spec.js
+++ b/test/falcor/deref/deref.errors.spec.js
@@ -3,6 +3,7 @@ var InvalidModelError = require('./../../../lib/errors/InvalidModelError');
 var InvalidDerefInputError = require('./../../../lib/errors/InvalidDerefInputError');
 var Model = falcor.Model;
 var sinon = require('sinon');
+var assert = require('chai').assert;
 var expect = require('chai').expect;
 var cacheGenerator = require('./../../CacheGenerator');
 var noOp = function() {};
@@ -56,4 +57,19 @@ describe('Error cases', function() {
         }
         done(new Error('should of thrown an error.'));
     });
+
+    it('should throw InvalidModelError on an invalidated deref path.', function() {
+        var model = new Model({cache: {titlesById: {32: {name: "House of Cards"}}}});
+        return model.get(["titlesById", 32, "name"]).
+            then(function(response) {
+                var titleModel = model.deref(response.json.titlesById[32]);
+                model.invalidate(["titlesById"]);
+                return titleModel.get(["name"]).
+                    then(assert.fail).
+                    catch(function(err) {
+                        expect(err.message).to.equals(InvalidModelError.message);
+                    });
+            });
+    });
+
 });


### PR DESCRIPTION
Currently TypeErrors are thrown from property access of undefined for invalidated deref path get and set. For get we should return a criticalError, but I'm not sure what we should do for set.
