### PR TITLE
Fixes setPathValues when setting with null as last key and hard references.

### DIFF
--- a/lib/set/setPathValues.js
+++ b/lib/set/setPathValues.js
@@ -193,7 +193,7 @@ function setNode(
         type = node.$type;
     }
 
-    if (type !== void 0) {
+    if (branch && type !== void 0) {
         return [node, parent];
     }
 

--- a/test/set/pathValues/atom.spec.js
+++ b/test/set/pathValues/atom.spec.js
@@ -167,6 +167,25 @@ describe("an atom", function() {
         }));
     });
 
+    it("through a reference that lands on an atom with a null last key", function() {
+
+        var cache = {};
+        var version = 0;
+        setPathValues(
+            getModel({ cache: cache, version: version++ }), [
+                $pathValue("foo.value", $ref("bar.value")),
+                $pathValue("bar.value", $atom("bar-value")),
+                $pathValue(["foo", "value", null], $atom("foo-value-1")),
+                $pathValue(["foo", "value", null], $atom("foo-value-2"))
+            ]
+        );
+
+        expect(strip(cache)).to.deep.equal(strip({
+            foo: { value: $ref("bar.value") },
+            bar: { value: $atom("foo-value-2") }
+        }));
+    });
+
     it("with an older timestamp", function() {
 
         var startTime = Date.now();

--- a/test/set/pathValues/primitive.spec.js
+++ b/test/set/pathValues/primitive.spec.js
@@ -152,6 +152,25 @@ describe("a primitive value", function() {
         }));
     });
 
+    it("through a reference that lands on an atom with a null last key", function() {
+
+        var cache = {};
+        var version = 0;
+        setPathValues(
+            getModel({ cache: cache, version: version++ }), [
+                $pathValue("foo.value", $ref("bar.value")),
+                $pathValue("bar.value", $atom("bar-value")),
+                $pathValue(["foo", "value", null], "foo-value-1"),
+                $pathValue(["foo", "value", null], "foo-value-2")
+            ]
+        );
+
+        expect(strip(cache)).to.deep.equal(strip({
+            foo: { value: $ref("bar.value") },
+            bar: { value: $atom("foo-value-2") }
+        }));
+    });
+
     describe("in multiple places", function() {
         describe("via keyset", function() {
             it("directly", function() {


### PR DESCRIPTION
This PR fixes the issue that set would improperly short-circuit if setting beyond a reference that points to a value if that reference was already hard-linked to the value.