### PR TITLE
Fix transpilation error to support React Native

### DIFF
--- a/lib/SymbolShim.js
+++ b/lib/SymbolShim.js
@@ -28,13 +28,15 @@ function ensureSymbol(root) {
 }
 
 function ensureObservable(Symbol) {
+    /* eslint-disable dot-notation */
     if (!Symbol.observable) {
         if (typeof Symbol.for === "function") {
-            Symbol.observable = Symbol.for("observable");
+            Symbol["observable"] = Symbol.for("observable");
         } else {
-            Symbol.observable = "@@observable";
+            Symbol["observable"] = "@@observable";
         }
     }
+    /* eslint-disable dot-notation */
 }
 
 function symbolForPolyfill(key) {
@@ -42,9 +44,11 @@ function symbolForPolyfill(key) {
 }
 
 function ensureFor(Symbol) {
+    /* eslint-disable dot-notation */
     if (!Symbol.for) {
-        Symbol.for = symbolForPolyfill;
+        Symbol["for"] = symbolForPolyfill;
     }
+    /* eslint-enable dot-notation */
 }
 
 


### PR DESCRIPTION
Recent versions of Babel will throw a TransformError in certain runtimes if any property on `Symbol` is assigned a value using dot notation, which includes React Native.  This makes sense, since you probably don't want to be assigning values on top of existing symbols anyway in environments that already support them.

<img width="250" alt="screen shot 2016-05-25 at 12 53 43 am" src="https://cloud.githubusercontent.com/assets/686352/15532464/d76289fa-2214-11e6-9d8a-e53f067459ee.png">

This retains the same polyfilling behavior for platforms without `Symbol.for` and `Symbol.observable`, but lets Babel properly transpile.  

With the change to Falcor to support Promise shimming merged in, this is the last remaining issue needed to support React Native in 1.x. Fixes #603.

@jhusain @sdesai @ktrott 