### PR TITLE
fix #601 - Maximum call stack size exceeded

### DIFF
--- a/lib/get/getCache.js
+++ b/lib/get/getCache.js
@@ -30,8 +30,9 @@ function cloneBoxedValue(boxedValue) {
 }
 
 function _copyCache(node, out, fromKey) {
+    if (!(typeof node === 'object')) return;
+    
     // copy and return
-
     Object.
         keys(node).
         filter(function(k) {


### PR DESCRIPTION
When `node` is a string, _copyCache gets stuck in an infinite loop. Checking to make sure `node` is an object first is the easy fix to this issue.