### PR TITLE
Fix case where error is returned with wrong path

### DIFF
--- a/lib/get/onError.js
+++ b/lib/get/onError.js
@@ -12,7 +12,7 @@ module.exports = function onError(model, node, depth,
         value = clone(node);
     }
     outerResults.errors.push({
-        path: requestedPath.slice(0, depth + 1),
+        path: requestedPath.slice(0, depth),
         value: value
     });
     promote(model._root, node);

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -116,6 +116,8 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         if (k !== null) {
             curr[k] = valueNode;
         } else {
+            // We are protected from reaching here when depth is 1 and prev is
+            // undefined by the InvalidModelError and NullInPathError checks.
             prev[prevK] = valueNode;
         }
     }

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -48,6 +48,7 @@ module.exports = function onValueType(
     else if (currType === $error) {
         if (fromReference) {
             requestedPath[depth] = null;
+            depth += 1;
         }
         if (isJSONG || model._treatErrorsAsValues) {
             onValue(model, node, seed, depth, outerResults, branchInfo,
@@ -62,6 +63,7 @@ module.exports = function onValueType(
     else {
         if (fromReference) {
             requestedPath[depth] = null;
+            depth += 1;
         }
 
         if (!requiresMaterializedToReport ||

--- a/test/get-core/errors.spec.js
+++ b/test/get-core/errors.spec.js
@@ -10,6 +10,19 @@ describe('Errors', function() {
     var expired = error('expired');
     expired.$expires = Date.now() - 1000;
 
+    var fooBranch = function() {
+        return {
+            $__path: ['foo'],
+            bar: {
+                $__path: ['foo', 'bar'],
+                baz: {
+                    $__path: ['foo', 'bar', 'baz'],
+                    qux: 'qux'
+                }
+            }
+        };
+    };
+
     var errorCache = function() {
         return {
             reference: ref(['to', 'error']),
@@ -21,6 +34,13 @@ describe('Errors', function() {
             list: {
                 0: ref(['to']),
                 1: ref(['to', 'error'])
+            },
+            foo: {
+                bar: {
+                    baz: {
+                        qux: 'qux'
+                    }
+                }
             }
         };
     };
@@ -29,6 +49,24 @@ describe('Errors', function() {
         getCoreRunner({
             input: [['to', 'error']],
             output: { },
+            errors: [{
+                path: ['to', 'error'],
+                value: 'Oops!'
+            }],
+            cache: errorCache
+        });
+    });
+    it('should report error with path when reusing walk arrays.', function() {
+        getCoreRunner({
+            input: [
+                ['foo', 'bar', 'baz', 'qux'],
+                ['to', 'error']
+            ],
+            output: {
+                json: {
+                    foo: fooBranch()
+                }
+            },
             errors: [{
                 path: ['to', 'error'],
                 value: 'Oops!'

--- a/test/get-core/errors.spec.js
+++ b/test/get-core/errors.spec.js
@@ -85,6 +85,17 @@ describe('Errors', function() {
             cache: errorCache
         });
     });
+    it('should report error path with null from reference with path ending in null.', function() {
+        getCoreRunner({
+            input: [['reference', null]],
+            output: { },
+            errors: [{
+                path: ['reference', null],
+                value: 'Oops!'
+            }],
+            cache: errorCache
+        });
+    });
     it('should report error with path in treateErrorsAsValues.', function() {
         var to = {
             error: 'Oops!'
@@ -94,6 +105,38 @@ describe('Errors', function() {
             input: [['to', 'error']],
             output: {
                 json: {
+                    to: to
+                }
+            },
+            treatErrorsAsValues: true,
+            cache: errorCache
+        });
+    });
+    it('should report error path with null from reference in treatErrorsAsValues.', function() {
+        getCoreRunner({
+            input: [['reference', 'title']],
+            output: {
+                json: {
+                    reference: 'Oops!'
+                }
+            },
+            treatErrorsAsValues: true,
+            cache: errorCache
+        });
+    });
+    it('should report error with path in treatErrorsAsValues when reusing walk arrays.', function() {
+        var to = {
+            error: 'Oops!'
+        };
+        to.$__path = ['to'];
+        getCoreRunner({
+            input: [
+                ['foo', 'bar', 'baz', 'qux'],
+                ['to', 'error']
+            ],
+            output: {
+                json: {
+                    foo: fooBranch(),
                     to: to
                 }
             },
@@ -111,6 +154,19 @@ describe('Errors', function() {
             output: {
                 json: {
                     to: to
+                }
+            },
+            treatErrorsAsValues: true,
+            boxValues: true,
+            cache: errorCache
+        });
+    });
+    it('should report error path with null from reference in treatErrorsAsValues and boxValues.', function() {
+        getCoreRunner({
+            input: [['reference', 'title']],
+            output: {
+                json: {
+                    reference: error('Oops!')
                 }
             },
             treatErrorsAsValues: true,

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -259,5 +259,29 @@ describe('Values', function() {
             }
         });
     });
+    it('should get JSONGraph to get a reference.', function() {
+        getCoreRunner({
+            input: [['reference']],
+            isJSONG: true,
+            output: {
+                jsonGraph: {
+                    "reference": {
+                        "$type": "ref",
+                        "value": ["foo", "bar"]
+                    }
+                },
+                paths: [
+                    ["reference"]
+                ]
+            },
+            cache: {
+                reference: jsonGraph.ref(['foo', 'bar']),
+                foo: {
+                    bar: atom('value')
+                }
+            }
+        });
+    });
+
 });
 

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -230,5 +230,34 @@ describe('Values', function() {
             cache: cacheGenerator(0, 30)
         });
     });
+    it('should get JSONGraph allow for a null at the end to get a value behind a reference.', function() {
+        getCoreRunner({
+            input: [['reference', null]],
+            isJSONG: true,
+            output: {
+                jsonGraph: {
+                    "reference": {
+                        "$type": "ref",
+                        "value": ["foo", "bar"]
+                    },
+                    "foo": {
+                        "bar": {
+                            "$type": "atom",
+                            "value": "value"
+                        }
+                    }
+                },
+                paths: [
+                    ["reference", null]
+                ]
+            },
+            cache: {
+                reference: jsonGraph.ref(['foo', 'bar']),
+                foo: {
+                    bar: atom('value')
+                }
+            }
+        });
+    });
 });
 


### PR DESCRIPTION
Looking at get.js I suspect there may be similar problems with derefInfo and optimizedPath. Alternatively we could avoid mutating requestedPath/branchInfo/optimizedPath in walkPath.js.