### PR TITLE
Allow error selector to change type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -------------------
 
 ## Features
+- [Allow errorSelector to change $type](https://github.com/Netflix/falcor/issues/828)
 - [Falcor.keys](https://github.com/Netflix/falcor/issues/708)
   - Adds a function to the namespace of `falcor` for ease of json key iteration.
 - [Remove Rx From Core](https://github.com/Netflix/falcor/issues/465)

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -144,6 +144,7 @@ module.exports = function mergeJSONGraphNode(
 
         if (mType === $error && isFunction(errorSelector)) {
             message = errorSelector(reconstructPath(requestedPath, key), message);
+            mType = message.$type || mType;
         }
 
         if (mType && node === message) {

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -149,7 +149,7 @@ module.exports = function mergeJSONGraphNode(
 
         if (mType && node === message) {
             if (node.ツparent == null) {
-                node = wrapNode(node, cType, node.value);
+                node = wrapNode(node, mType, node.value);
                 parent = updateNodeAncestors(parent, -node.$size, lru, version);
                 node = insertNode(node, parent, key, version, optimizedPath);
             }

--- a/lib/support/mergeValueOrInsertBranch.js
+++ b/lib/support/mergeValueOrInsertBranch.js
@@ -51,6 +51,7 @@ module.exports = function mergeValueOrInsertBranch(
 
             if (mType === $error && isFunction(errorSelector)) {
                 message = errorSelector(reconstructPath(requestedPath, key), message);
+                mType = message.$type || mType;
             }
 
             message = wrapNode(message, mType, mType ? message.value : message);

--- a/test/falcor/set/set.cache-only.spec.js
+++ b/test/falcor/set/set.cache-only.spec.js
@@ -222,6 +222,60 @@ describe('Cache Only', function() {
                     });
         });
 
+        it('should be allowed to change $type', function(done) {
+
+            var testPath = ['genreList', 0, 0, 'errorPath'];
+
+            var modelCache = Cache();
+
+            var onNextSpy = sinon.spy();
+            var onErrorSpy = sinon.spy();
+
+            var model = new Model({
+                cache : modelCache,
+                errorSelector : function(path, atom) {
+                    var o = {
+                        $type: 'atom',
+                        $custom: 'custom',
+                        value: {
+                            message: atom.value.message,
+                            customtype: 'customtype'
+                        }
+                    };
+
+                    return o;
+                }
+            });
+
+            toObservable(model.
+                boxValues().
+                setValue(testPath, jsonGraph.error({message:'errormsg'}))).
+                doAction(onNextSpy, onErrorSpy, noOp).
+                subscribe(
+                    noOp,
+                    function(e) {
+                        expect(onErrorSpy.callCount).to.equal(0);
+                        done();
+                    },
+                    function() {
+
+                        expect(onErrorSpy.callCount).to.equal(0);
+                        expect(onNextSpy.callCount).to.equal(1);
+
+                        expect(onNextSpy.getCall(0).args[0]).to.deep.equals({
+                            $type: 'atom',
+                            $custom: 'custom',
+                            value: {
+                                message: 'errormsg',
+                                customtype: 'customtype'
+                            },
+                            $size:51
+                        });
+
+                        done();
+                    });
+        });
+
     });
 
 });


### PR DESCRIPTION
This allows the errorSelector to change the $type of the leaf payload it gets in. So users can change certain errors, based on their payload, to an atom for example, if there is client side knowledge about values which can substitute for those errors.

We currently use this to fill out missing strings we request from the server, with reasonable client side defaults [ IIRC ]. We may still need to iterate on this, to see if we want to expand it's scope [ e.g. should the hook just become a general transformValueBeforeMerge hook - why does it just get errors as input. Are there use cases which warrant it getting non-errors also ].

@jhusain @lrowe @blesh @forty2