### PR TITLE
Log the path when throwing InvalidModelError.

### DIFF
--- a/lib/deref/sync.js
+++ b/lib/deref/sync.js
@@ -23,7 +23,7 @@ module.exports = function derefSync(boundPathArg) {
     }
 
     if (node.$type) {
-        throw new InvalidModelError();
+        throw new InvalidModelError(path, path);
     }
 
     return this._clone({ _path: path });


### PR DESCRIPTION
This is the same case as Model.get, so boundPath and shortedPath are both set to path.