### PR TITLE
Changing from unicode smiley face to 'lib/values'

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -410,6 +410,7 @@ Model.prototype._setMaxSize = function setMaxSize(maxSize) {
     if (maxSize < oldMaxSize) {
         var modelRoot = this._root;
         var modelCache = modelRoot.cache;
+        // eslint-disable-next-line no-cond-assign
         var currentVersion = modelCache.$_version;
         collectLru(modelRoot, modelRoot.expired, getSize(modelCache),
                 this._maxSize, this._collectRatio, currentVersion);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -410,7 +410,7 @@ Model.prototype._setMaxSize = function setMaxSize(maxSize) {
     if (maxSize < oldMaxSize) {
         var modelRoot = this._root;
         var modelCache = modelRoot.cache;
-        var currentVersion = modelCache.ツversion;
+        var currentVersion = modelCache.$_version;
         collectLru(modelRoot, modelRoot.expired, getSize(modelCache),
                 this._maxSize, this._collectRatio, currentVersion);
     }

--- a/lib/deref/hasValidParentReference.js
+++ b/lib/deref/hasValidParentReference.js
@@ -18,12 +18,12 @@ module.exports = function fromWhenceYeCame() {
     }
 
     // Its been disconnected (set over or collected) from the graph.
-    if (reference && reference.ツparent === undefined) {
+    if (reference && reference.$_parent === undefined) {
         return false;
     }
 
     // The reference has expired but has not been collected from the graph.
-    if (reference && reference.ツinvalidated) {
+    if (reference && reference.$_invalidated) {
         return false;
     }
 

--- a/lib/deref/hasValidParentReference.js
+++ b/lib/deref/hasValidParentReference.js
@@ -18,11 +18,13 @@ module.exports = function fromWhenceYeCame() {
     }
 
     // Its been disconnected (set over or collected) from the graph.
+    // eslint-disable-next-line camelcase
     if (reference && reference.$_parent === undefined) {
         return false;
     }
 
     // The reference has expired but has not been collected from the graph.
+    // eslint-disable-next-line camelcase
     if (reference && reference.$_invalidated) {
         return false;
     }

--- a/lib/get/followReference.js
+++ b/lib/get/followReference.js
@@ -15,9 +15,9 @@ function followReference(model, root, nodeArg, referenceContainerArg,
     var k, next;
 
     while (true) {
-        if (depth === 0 && referenceContainer.ツcontext) {
+        if (depth === 0 && referenceContainer.$_context) {
             depth = reference.length;
-            next = referenceContainer.ツcontext;
+            next = referenceContainer.$_context;
         } else {
             k = reference[depth++];
             next = node[k];
@@ -45,7 +45,7 @@ function followReference(model, root, nodeArg, referenceContainerArg,
                     break;
                 }
 
-                if (!referenceContainer.ツcontext) {
+                if (!referenceContainer.$_context) {
                     createHardlink(referenceContainer, next);
                 }
 

--- a/lib/get/getCache.js
+++ b/lib/get/getCache.js
@@ -54,7 +54,7 @@ function _copyCache(node, out, fromKey) {
             // Paste the node into the out cache.
             if (cacheNext.$type) {
                 var isObject = cacheNext.value && typeof cacheNext.value === "object";
-                var isUserCreatedcacheNext = !cacheNext.ツmodelCreated;
+                var isUserCreatedcacheNext = !cacheNext.$_modelCreated;
                 var value;
                 if (isObject || isUserCreatedcacheNext) {
                     value = cloneBoxedValue(cacheNext);

--- a/lib/get/getVersion.js
+++ b/lib/get/getVersion.js
@@ -5,6 +5,6 @@ module.exports = function _getVersion(model, path) {
         _root: model._root,
         _treatErrorsAsValues: model._treatErrorsAsValues
     }, path, true).value;
-    var version = gen && gen.ツversion;
+    var version = gen && gen.$_version;
     return (version == null) ? -1 : version;
 };

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -45,7 +45,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
 
     else if (isJSONG) {
         var isObject = node.value && typeof node.value === "object";
-        var isUserCreatedNode = !node.ツmodelCreated;
+        var isUserCreatedNode = !node.$_modelCreated;
         if (isObject || isUserCreatedNode) {
             valueNode = clone(node);
         } else {

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -36,7 +36,7 @@ module.exports = function onValueType(
 
     // If there are expired value, then report it as missing
     else if (isExpired(node)) {
-        if (!node.ツinvalidated) {
+        if (!node.$_invalidated) {
             expireNode(node, model._root.expired, model._root);
         }
         onMissing(model, path, depth,

--- a/lib/get/util/clone.js
+++ b/lib/get/util/clone.js
@@ -1,5 +1,5 @@
 // Copies the node
-var unicodePrefix = require("./../../internal/unicodePrefix");
+var privatePrefix = require("./../../internal/privatePrefix");
 
 module.exports = function clone(node) {
     var outValue, i, len;
@@ -7,12 +7,11 @@ module.exports = function clone(node) {
     outValue = {};
     for (i = 0, len = keys.length; i < len; i++) {
         var k = keys[i];
-        var k0 = k.charAt(0);
-        if (k0 === unicodePrefix) {
+        var k0 = k.substr(0, 2);
+        if (k0 === privatePrefix) {
             continue;
         }
         outValue[k] = node[k];
     }
     return outValue;
 };
-

--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -119,8 +119,11 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // There was a reference container.
                 if (referenceContainer && allowFromWhenceYouCame) {
                     obj = {
+                        // eslint-disable-next-line camelcase
                         $__path: next.$_absolutePath,
+                        // eslint-disable-next-line camelcase
                         $__refPath: referenceContainer.value,
+                        // eslint-disable-next-line camelcase
                         $__toReference: referenceContainer.$_absolutePath
                     };
                 }
@@ -130,6 +133,7 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // contain references.
                 else {
                     obj = {
+                        // eslint-disable-next-line camelcase
                         $__path: next.$_absolutePath
                     };
                 }

--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -119,9 +119,9 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // There was a reference container.
                 if (referenceContainer && allowFromWhenceYouCame) {
                     obj = {
-                        $__path: next.ツabsolutePath,
+                        $__path: next.$_absolutePath,
                         $__refPath: referenceContainer.value,
-                        $__toReference: referenceContainer.ツabsolutePath
+                        $__toReference: referenceContainer.$_absolutePath
                     };
                 }
 
@@ -130,7 +130,7 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
                 // contain references.
                 else {
                     obj = {
-                        $__path: next.ツabsolutePath
+                        $__path: next.$_absolutePath
                     };
                 }
 

--- a/lib/internal/absolutePath.js
+++ b/lib/internal/absolutePath.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "absolutePath";
+module.exports = require("./privatePrefix") + "absolutePath";

--- a/lib/internal/context.js
+++ b/lib/internal/context.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "context";
+module.exports = require("./privatePrefix") + "context";

--- a/lib/internal/head.js
+++ b/lib/internal/head.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "head";
+module.exports = require("./privatePrefix") + "head";

--- a/lib/internal/index.js
+++ b/lib/internal/index.js
@@ -3,7 +3,10 @@
  * have them as one exports.  This makes the bundling overhead smaller!
  */
 module.exports = {
+    // eslint-disable-next-line camelcase
     $__toReference: "$__toReference",
+    // eslint-disable-next-line camelcase
     $__path: "$__path",
+    // eslint-disable-next-line camelcase
     $__refPath: "$__refPath"
 };

--- a/lib/internal/invalidated.js
+++ b/lib/internal/invalidated.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "invalidated";
+module.exports = require("./privatePrefix") + "invalidated";

--- a/lib/internal/key.js
+++ b/lib/internal/key.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "key";
+module.exports = require("./privatePrefix") + "key";

--- a/lib/internal/model-created.js
+++ b/lib/internal/model-created.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "modelCreated";
+module.exports = require("./privatePrefix") + "modelCreated";

--- a/lib/internal/next.js
+++ b/lib/internal/next.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "next";
+module.exports = require("./privatePrefix") + "next";

--- a/lib/internal/parent.js
+++ b/lib/internal/parent.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "parent";
+module.exports = require("./privatePrefix") + "parent";

--- a/lib/internal/path.js
+++ b/lib/internal/path.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "path";
+module.exports = require("./privatePrefix") + "path";

--- a/lib/internal/prev.js
+++ b/lib/internal/prev.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "prev";
+module.exports = require("./privatePrefix") + "prev";

--- a/lib/internal/privatePrefix.js
+++ b/lib/internal/privatePrefix.js
@@ -1,0 +1,3 @@
+var reservedPrefix = require("./reservedPrefix");
+
+module.exports = reservedPrefix + "_";

--- a/lib/internal/ref-index.js
+++ b/lib/internal/ref-index.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "refIndex";
+module.exports = require("./privatePrefix") + "refIndex";

--- a/lib/internal/ref.js
+++ b/lib/internal/ref.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "ref";
+module.exports = require("./privatePrefix") + "ref";

--- a/lib/internal/refs-length.js
+++ b/lib/internal/refs-length.js
@@ -1,2 +1,1 @@
-module.exports = require("./unicodePrefix") + "refsLength";
-
+module.exports = require("./privatePrefix") + "refsLength";

--- a/lib/internal/reservedPrefix.js
+++ b/lib/internal/reservedPrefix.js
@@ -1,0 +1,1 @@
+module.exports = "$";

--- a/lib/internal/tail.js
+++ b/lib/internal/tail.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "tail";
+module.exports = require("./privatePrefix") + "tail";

--- a/lib/internal/unicodePrefix.js
+++ b/lib/internal/unicodePrefix.js
@@ -1,2 +1,0 @@
-module.exports = "ツ";
-

--- a/lib/internal/version.js
+++ b/lib/internal/version.js
@@ -1,1 +1,1 @@
-module.exports = require("./unicodePrefix") + "version";
+module.exports = require("./privatePrefix") + "version";

--- a/lib/invalidate/invalidatePathMaps.js
+++ b/lib/invalidate/invalidatePathMaps.js
@@ -1,5 +1,5 @@
 var createHardlink = require("../support/createHardlink");
-var __prefix = require("./../internal/unicodePrefix");
+var __prefix = require("./../internal/reservedPrefix");
 
 var $ref = require("./../types/ref");
 
@@ -35,8 +35,8 @@ module.exports = function invalidatePathMaps(model, pathMapEnvelopes) {
     var bound = model._path;
     var cache = modelRoot.cache;
     var node = bound.length ? getBoundValue(model, bound).value : cache;
-    var parent = node.ツparent || cache;
-    var initialVersion = cache.ツversion;
+    var parent = node.$_parent || cache;
+    var initialVersion = cache.$_version;
 
     var pathMapIndex = -1;
     var pathMapCount = pathMapEnvelopes.length;
@@ -51,7 +51,7 @@ module.exports = function invalidatePathMaps(model, pathMapEnvelopes) {
         );
     }
 
-    var newVersion = cache.ツversion;
+    var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
@@ -66,7 +66,7 @@ function invalidatePathMap(pathMap, depth, root, parent, node, version, expired,
     }
 
     for (var key in pathMap) {
-        if (key[0] !== __prefix && key[0] !== "$" && hasOwn(pathMap, key)) {
+        if (key[0] !== __prefix && hasOwn(pathMap, key)) {
             var child = pathMap[key];
             var branch = isObject(child) && !child.$type;
             var results = invalidateNode(
@@ -104,10 +104,10 @@ function invalidateReference(value, root, node, version, expired, lru, comparato
     var reference = node.value;
     var parent = root;
 
-    node = node.ツcontext;
+    node = node.$_context;
 
     if (node != null) {
-        parent = node.ツparent || root;
+        parent = node.$_parent || root;
     } else {
 
         var index = 0;
@@ -130,7 +130,7 @@ function invalidateReference(value, root, node, version, expired, lru, comparato
             parent = results[1];
         } while (index++ < count);
 
-        if (container.ツcontext !== node) {
+        if (container.$_context !== node) {
             createHardlink(container, node);
         }
     }
@@ -167,7 +167,7 @@ function invalidateNode(
         if (branch) {
             throw new Error("`null` is not allowed in branch key positions.");
         } else if (node) {
-            key = node.ツkey;
+            key = node.$_key;
         }
     } else {
         parent = node;

--- a/lib/invalidate/invalidatePathSets.js
+++ b/lib/invalidate/invalidatePathSets.js
@@ -31,8 +31,8 @@ module.exports = function invalidatePathSets(model, paths) {
     var bound = model._path;
     var cache = modelRoot.cache;
     var node = bound.length ? getBoundValue(model, bound).value : cache;
-    var parent = node.ツparent || cache;
-    var initialVersion = cache.ツversion;
+    var parent = node.$_parent || cache;
+    var initialVersion = cache.$_version;
 
     var pathIndex = -1;
     var pathCount = paths.length;
@@ -47,7 +47,7 @@ module.exports = function invalidatePathSets(model, paths) {
         );
     }
 
-    var newVersion = cache.ツversion;
+    var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
@@ -100,10 +100,10 @@ function invalidateReference(root, node, version, expired, lru) {
     var reference = node.value;
     var parent = root;
 
-    node = node.ツcontext;
+    node = node.$_context;
 
     if (node != null) {
-        parent = node.ツparent || root;
+        parent = node.$_parent || root;
     } else {
 
         var index = 0;
@@ -126,12 +126,12 @@ function invalidateReference(root, node, version, expired, lru) {
             parent = results[1];
         } while (index++ < count);
 
-        if (container.ツcontext !== node) {
-            var backRefs = node.ツrefsLength || 0;
-            node.ツrefsLength = backRefs + 1;
+        if (container.$_context !== node) {
+            var backRefs = node.$_refsLength || 0;
+            node.$_refsLength = backRefs + 1;
             node[__ref + backRefs] = container;
-            container.ツcontext = node;
-            container.ツrefIndex = backRefs;
+            container.$_context = node;
+            container.$_refIndex = backRefs;
         }
     }
 
@@ -167,7 +167,7 @@ function invalidateNode(
         if (branch) {
             throw new Error("`null` is not allowed in branch key positions.");
         } else if (node) {
-            key = node.ツkey;
+            key = node.$_key;
         }
     } else {
         parent = node;

--- a/lib/invalidate/invalidatePathSets.js
+++ b/lib/invalidate/invalidatePathSets.js
@@ -31,7 +31,9 @@ module.exports = function invalidatePathSets(model, paths) {
     var bound = model._path;
     var cache = modelRoot.cache;
     var node = bound.length ? getBoundValue(model, bound).value : cache;
+    // eslint-disable-next-line camelcase
     var parent = node.$_parent || cache;
+    // eslint-disable-next-line camelcase
     var initialVersion = cache.$_version;
 
     var pathIndex = -1;
@@ -47,6 +49,7 @@ module.exports = function invalidatePathSets(model, paths) {
         );
     }
 
+    // eslint-disable-next-line camelcase
     var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
@@ -100,9 +103,11 @@ function invalidateReference(root, node, version, expired, lru) {
     var reference = node.value;
     var parent = root;
 
+    // eslint-disable-next-line camelcase
     node = node.$_context;
 
     if (node != null) {
+        // eslint-disable-next-line camelcase
         parent = node.$_parent || root;
     } else {
 
@@ -126,11 +131,16 @@ function invalidateReference(root, node, version, expired, lru) {
             parent = results[1];
         } while (index++ < count);
 
+        // eslint-disable-next-line camelcase
         if (container.$_context !== node) {
+            // eslint-disable-next-line camelcase
             var backRefs = node.$_refsLength || 0;
+            // eslint-disable-next-line camelcase
             node.$_refsLength = backRefs + 1;
             node[__ref + backRefs] = container;
+            // eslint-disable-next-line camelcase
             container.$_context = node;
+            // eslint-disable-next-line camelcase
             container.$_refIndex = backRefs;
         }
     }

--- a/lib/lru/collect.js
+++ b/lib/lru/collect.js
@@ -21,17 +21,17 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
         total -= size;
         if (shouldUpdate === true) {
             updateNodeAncestors(node, size, lru, version);
-        } else if (parent = node.ツparent) {  // eslint-disable-line no-cond-assign
-            removeNode(node, parent, node.ツkey, lru);
+        } else if (parent = node.$_parent) {  // eslint-disable-line no-cond-assign
+            removeNode(node, parent, node.$_key, lru);
         }
         node = expired.pop();
     }
 
     if (total >= max) {
-        var prev = lru.ツtail;
+        var prev = lru.$_tail;
         node = prev;
         while ((total >= targetSize) && node) {
-            prev = prev.ツprev;
+            prev = prev.$_prev;
             size = node.$size || 0;
             total -= size;
             if (shouldUpdate === true) {
@@ -40,11 +40,11 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
             node = prev;
         }
 
-        lru.ツtail = lru.ツprev = node;
+        lru.$_tail = lru.$_prev = node;
         if (node == null) {
-            lru.ツhead = lru.ツnext = undefined;
+            lru.$_head = lru.$_next = undefined;
         } else {
-            node.ツnext = undefined;
+            node.$_next = undefined;
         }
     }
 };

--- a/lib/lru/collect.js
+++ b/lib/lru/collect.js
@@ -21,16 +21,20 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
         total -= size;
         if (shouldUpdate === true) {
             updateNodeAncestors(node, size, lru, version);
-        } else if (parent = node.$_parent) {  // eslint-disable-line no-cond-assign
+            // eslint-disable-next-line camelcase
+        } else if (parent = node.$_parent) { // eslint-disable-line no-cond-assign
+            // eslint-disable-next-line camelcase
             removeNode(node, parent, node.$_key, lru);
         }
         node = expired.pop();
     }
 
     if (total >= max) {
+        // eslint-disable-next-line camelcase
         var prev = lru.$_tail;
         node = prev;
         while ((total >= targetSize) && node) {
+            // eslint-disable-next-line camelcase
             prev = prev.$_prev;
             size = node.$size || 0;
             total -= size;
@@ -40,10 +44,13 @@ module.exports = function collect(lru, expired, totalArg, max, ratioArg, version
             node = prev;
         }
 
+        // eslint-disable-next-line camelcase
         lru.$_tail = lru.$_prev = node;
         if (node == null) {
+            // eslint-disable-next-line camelcase
             lru.$_head = lru.$_next = undefined;
         } else {
+            // eslint-disable-next-line camelcase
             node.$_next = undefined;
         }
     }

--- a/lib/lru/promote.js
+++ b/lib/lru/promote.js
@@ -8,10 +8,12 @@ module.exports = function lruPromote(root, object) {
         return;
     }
 
+    // eslint-disable-next-line camelcase
     var head = root.$_head;
 
     // Nothing is in the cache.
     if (!head) {
+        // eslint-disable-next-line camelcase
         root.$_head = root.$_tail = object;
         return;
     }
@@ -22,23 +24,33 @@ module.exports = function lruPromote(root, object) {
 
     // The item always exist in the cache since to get anything in the
     // cache it first must go through set.
+    // eslint-disable-next-line camelcase
     var prev = object.$_prev;
+    // eslint-disable-next-line camelcase
     var next = object.$_next;
     if (next) {
+        // eslint-disable-next-line camelcase
         next.$_prev = prev;
     }
     if (prev) {
+        // eslint-disable-next-line camelcase
         prev.$_next = next;
     }
+    // eslint-disable-next-line camelcase
     object.$_prev = undefined;
 
     // Insert into head position
+    // eslint-disable-next-line camelcase
     root.$_head = object;
+    // eslint-disable-next-line camelcase
     object.$_next = head;
+    // eslint-disable-next-line camelcase
     head.$_prev = object;
 
     // If the item we promoted was the tail, then set prev to tail.
+    // eslint-disable-next-line camelcase
     if (object === root.$_tail) {
+        // eslint-disable-next-line camelcase
         root.$_tail = prev;
     }
 };

--- a/lib/lru/promote.js
+++ b/lib/lru/promote.js
@@ -8,11 +8,11 @@ module.exports = function lruPromote(root, object) {
         return;
     }
 
-    var head = root.ツhead;
+    var head = root.$_head;
 
     // Nothing is in the cache.
     if (!head) {
-        root.ツhead = root.ツtail = object;
+        root.$_head = root.$_tail = object;
         return;
     }
 
@@ -22,23 +22,23 @@ module.exports = function lruPromote(root, object) {
 
     // The item always exist in the cache since to get anything in the
     // cache it first must go through set.
-    var prev = object.ツprev;
-    var next = object.ツnext;
+    var prev = object.$_prev;
+    var next = object.$_next;
     if (next) {
-        next.ツprev = prev;
+        next.$_prev = prev;
     }
     if (prev) {
-        prev.ツnext = next;
+        prev.$_next = next;
     }
-    object.ツprev = undefined;
+    object.$_prev = undefined;
 
     // Insert into head position
-    root.ツhead = object;
-    object.ツnext = head;
-    head.ツprev = object;
+    root.$_head = object;
+    object.$_next = head;
+    head.$_prev = object;
 
     // If the item we promoted was the tail, then set prev to tail.
-    if (object === root.ツtail) {
-        root.ツtail = prev;
+    if (object === root.$_tail) {
+        root.$_tail = prev;
     }
 };

--- a/lib/lru/splice.js
+++ b/lib/lru/splice.js
@@ -23,7 +23,7 @@ module.exports = function lruSplice(root, object) {
     }
     // eslint-disable-next-line camelcase
     if (object === root.$_tail) {
-        // eslint-disable-next-line camelcase      
+        // eslint-disable-next-line camelcase
         root.$_tail = prev;
     }
 };

--- a/lib/lru/splice.js
+++ b/lib/lru/splice.js
@@ -1,20 +1,29 @@
 module.exports = function lruSplice(root, object) {
 
     // Its in the cache.  Splice out.
+    // eslint-disable-next-line camelcase
     var prev = object.$_prev;
+    // eslint-disable-next-line camelcase
     var next = object.$_next;
     if (next) {
+        // eslint-disable-next-line camelcase
         next.$_prev = prev;
     }
     if (prev) {
+        // eslint-disable-next-line camelcase
         prev.$_next = next;
     }
+    // eslint-disable-next-line camelcase
     object.$_prev = object.$_next = undefined;
 
+    // eslint-disable-next-line camelcase
     if (object === root.$_head) {
+        // eslint-disable-next-line camelcase
         root.$_head = next;
     }
+    // eslint-disable-next-line camelcase
     if (object === root.$_tail) {
+        // eslint-disable-next-line camelcase      
         root.$_tail = prev;
     }
 };

--- a/lib/lru/splice.js
+++ b/lib/lru/splice.js
@@ -1,20 +1,20 @@
 module.exports = function lruSplice(root, object) {
 
     // Its in the cache.  Splice out.
-    var prev = object.ツprev;
-    var next = object.ツnext;
+    var prev = object.$_prev;
+    var next = object.$_next;
     if (next) {
-        next.ツprev = prev;
+        next.$_prev = prev;
     }
     if (prev) {
-        prev.ツnext = next;
+        prev.$_next = next;
     }
-    object.ツprev = object.ツnext = undefined;
+    object.$_prev = object.$_next = undefined;
 
-    if (object === root.ツhead) {
-        root.ツhead = next;
+    if (object === root.$_head) {
+        root.$_head = next;
     }
-    if (object === root.ツtail) {
-        root.ツtail = prev;
+    if (object === root.$_tail) {
+        root.$_tail = prev;
     }
 };

--- a/lib/response/get/GetResponse.js
+++ b/lib/response/get/GetResponse.js
@@ -67,7 +67,7 @@ GetResponse.prototype._subscribe = function _subscribe(observer) {
         if (this.forceCollect) {
             var modelRoot = model._root;
             var modelCache = modelRoot.cache;
-            var currentVersion = modelCache.ツversion;
+            var currentVersion = modelCache.$_version;
 
             collectLru(modelRoot, modelRoot.expired, getSize(modelCache),
                     model._maxSize, model._collectRatio, currentVersion);

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -79,7 +79,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
 
                 var modelRoot = model._root;
                 var modelCache = modelRoot.cache;
-                var currentVersion = modelCache.ツversion;
+                var currentVersion = modelCache.$_version;
 
                 collectLru(modelRoot, modelRoot.expired, getSize(modelCache),
                         model._maxSize, model._collectRatio, currentVersion);

--- a/lib/set/setJSONGraphs.js
+++ b/lib/set/setJSONGraphs.js
@@ -25,7 +25,7 @@ module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelec
     var expired = modelRoot.expired;
     var version = incrementVersion();
     var cache = modelRoot.cache;
-    var initialVersion = cache.ツversion;
+    var initialVersion = cache.$_version;
 
     var requestedPath = [];
     var optimizedPath = [];
@@ -58,7 +58,7 @@ module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelec
         }
     }
 
-    var newVersion = cache.ツversion;
+    var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
@@ -160,7 +160,7 @@ function setReference(
 
     optimizedPath.index = index;
 
-    if (container.ツcontext !== node) {
+    if (container.$_context !== node) {
         createHardlink(container, node);
     }
 
@@ -201,7 +201,7 @@ function setNode(
         if (branch) {
             throw new NullInPathError();
         } else if (node) {
-            key = node.ツkey;
+            key = node.$_key;
         }
     } else {
         parent = node;

--- a/lib/set/setPathMaps.js
+++ b/lib/set/setPathMaps.js
@@ -1,5 +1,5 @@
 var createHardlink = require("./../support/createHardlink");
-var __prefix = require("./../internal/unicodePrefix");
+var __prefix = require("./../internal/reservedPrefix");
 var $ref = require("./../types/ref");
 
 var getBoundValue = require("./../get/getBoundValue");
@@ -32,8 +32,8 @@ module.exports = function setPathMaps(model, pathMapEnvelopes, x, errorSelector,
     var bound = model._path;
     var cache = modelRoot.cache;
     var node = bound.length ? getBoundValue(model, bound).value : cache;
-    var parent = node.ツparent || cache;
-    var initialVersion = cache.ツversion;
+    var parent = node.$_parent || cache;
+    var initialVersion = cache.$_version;
 
     var requestedPath = [];
     var requestedPaths = [];
@@ -55,7 +55,7 @@ module.exports = function setPathMaps(model, pathMapEnvelopes, x, errorSelector,
         );
     }
 
-    var newVersion = cache.ツversion;
+    var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
@@ -137,10 +137,10 @@ function setReference(
     var container = node;
     var parent = root;
 
-    node = node.ツcontext;
+    node = node.$_context;
 
     if (node != null) {
-        parent = node.ツparent || root;
+        parent = node.$_parent || root;
         optimizedPath.index = reference.length;
     } else {
 
@@ -168,7 +168,7 @@ function setReference(
 
         optimizedPath.index = index;
 
-        if (container.ツcontext !== node) {
+        if (container.$_context !== node) {
             createHardlink(container, node);
         }
     }
@@ -207,7 +207,7 @@ function setNode(
         if (branch) {
             throw new NullInPathError();
         } else if (node) {
-            key = node.ツkey;
+            key = node.$_key;
         }
     } else {
         parent = node;
@@ -232,7 +232,7 @@ function getKeys(pathMap) {
             keys[itr++] = "length";
         }
         for (var key in pathMap) {
-            if (key[0] === __prefix || key[0] === "$" || !hasOwn(pathMap, key)) {
+            if (key[0] === __prefix || !hasOwn(pathMap, key)) {
                 continue;
             }
             keys[itr++] = key;

--- a/lib/set/setPathValues.js
+++ b/lib/set/setPathValues.js
@@ -29,8 +29,8 @@ module.exports = function setPathValues(model, pathValues, x, errorSelector, com
     var bound = model._path;
     var cache = modelRoot.cache;
     var node = bound.length ? getBoundValue(model, bound).value : cache;
-    var parent = node.ツparent || cache;
-    var initialVersion = cache.ツversion;
+    var parent = node.$_parent || cache;
+    var initialVersion = cache.$_version;
 
     var requestedPath = [];
     var requestedPaths = [];
@@ -54,7 +54,7 @@ module.exports = function setPathValues(model, pathValues, x, errorSelector, com
         );
     }
 
-    var newVersion = cache.ツversion;
+    var newVersion = cache.$_version;
     var rootChangeHandler = modelRoot.onChange;
 
     if (isFunction(rootChangeHandler) && initialVersion !== newVersion) {
@@ -129,10 +129,10 @@ function setReference(
     var container = node;
     var parent = root;
 
-    node = node.ツcontext;
+    node = node.$_context;
 
     if (node != null) {
-        parent = node.ツparent || root;
+        parent = node.$_parent || root;
         optimizedPath.index = reference.length;
     } else {
 
@@ -161,7 +161,7 @@ function setReference(
 
         optimizedPath.index = index;
 
-        if (container.ツcontext !== node) {
+        if (container.$_context !== node) {
             createHardlink(container, node);
         }
     }
@@ -201,7 +201,7 @@ function setNode(
         if (branch) {
             throw new NullInPathError();
         } else if (node) {
-            key = node.ツkey;
+            key = node.$_key;
         }
     } else {
         parent = node;

--- a/lib/support/clone.js
+++ b/lib/support/clone.js
@@ -1,4 +1,4 @@
-var unicodePrefix = require("./../internal/unicodePrefix");
+var privatePrefix = require("./../internal/privatePrefix");
 var hasOwn = require("./../support/hasOwn");
 var isArray = Array.isArray;
 var isObject = require("./../support/isObject");
@@ -9,7 +9,7 @@ module.exports = function clone(value) {
         dest = isArray(value) ? [] : {};
         var src = value;
         for (var key in src) {
-            if (key.charAt(0) === unicodePrefix || !hasOwn(src, key)) {
+            if (key.substr(0,2) === privatePrefix || !hasOwn(src, key)) {
                 continue;
             }
             dest[key] = src[key];

--- a/lib/support/createHardlink.js
+++ b/lib/support/createHardlink.js
@@ -3,11 +3,15 @@ var __ref = require("./../internal/ref");
 module.exports = function createHardlink(from, to) {
 
     // create a back reference
+    // eslint-disable-next-line camelcase
     var backRefs = to.$_refsLength || 0;
     to[__ref + backRefs] = from;
+    // eslint-disable-next-line camelcase
     to.$_refsLength = backRefs + 1;
 
     // create a hard reference
+    // eslint-disable-next-line camelcase
     from.$_refIndex = backRefs;
+    // eslint-disable-next-line camelcase
     from.$_context = to;
 };

--- a/lib/support/createHardlink.js
+++ b/lib/support/createHardlink.js
@@ -3,11 +3,11 @@ var __ref = require("./../internal/ref");
 module.exports = function createHardlink(from, to) {
 
     // create a back reference
-    var backRefs = to.ツrefsLength || 0;
+    var backRefs = to.$_refsLength || 0;
     to[__ref + backRefs] = from;
-    to.ツrefsLength = backRefs + 1;
+    to.$_refsLength = backRefs + 1;
 
     // create a hard reference
-    from.ツrefIndex = backRefs;
-    from.ツcontext = to;
+    from.$_refIndex = backRefs;
+    from.$_context = to;
 };

--- a/lib/support/expireNode.js
+++ b/lib/support/expireNode.js
@@ -1,8 +1,8 @@
 var splice = require("./../lru/splice");
 
 module.exports = function expireNode(node, expired, lru) {
-    if (!node.ツinvalidated) {
-        node.ツinvalidated = true;
+    if (!node.$_invalidated) {
+        node.$_invalidated = true;
         expired.push(node);
         splice(lru, node);
     }

--- a/lib/support/expireNode.js
+++ b/lib/support/expireNode.js
@@ -1,7 +1,9 @@
 var splice = require("./../lru/splice");
 
 module.exports = function expireNode(node, expired, lru) {
+    // eslint-disable-next-line camelcase
     if (!node.$_invalidated) {
+        // eslint-disable-next-line camelcase
         node.$_invalidated = true;
         expired.push(node);
         splice(lru, node);

--- a/lib/support/insertNode.js
+++ b/lib/support/insertNode.js
@@ -1,11 +1,16 @@
 module.exports = function insertNode(node, parent, key, version, optimizedPath) {
+    // eslint-disable-next-line camelcase
     node.$_key = key;
+    // eslint-disable-next-line camelcase
     node.$_parent = parent;
 
     if (version !== undefined) {
+        // eslint-disable-next-line camelcase
         node.$_version = version;
     }
+    // eslint-disable-next-line camelcase
     if (!node.$_absolutePath) {
+        // eslint-disable-next-line camelcase
         node.$_absolutePath = optimizedPath.slice(0, optimizedPath.index).concat(key);
     }
 

--- a/lib/support/insertNode.js
+++ b/lib/support/insertNode.js
@@ -1,12 +1,12 @@
 module.exports = function insertNode(node, parent, key, version, optimizedPath) {
-    node.ツkey = key;
-    node.ツparent = parent;
+    node.$_key = key;
+    node.$_parent = parent;
 
     if (version !== undefined) {
-        node.ツversion = version;
+        node.$_version = version;
     }
-    if (!node.ツabsolutePath) {
-        node.ツabsolutePath = optimizedPath.slice(0, optimizedPath.index).concat(key);
+    if (!node.$_absolutePath) {
+        node.$_absolutePath = optimizedPath.slice(0, optimizedPath.index).concat(key);
     }
 
     parent[key] = node;

--- a/lib/support/isInternalKey.js
+++ b/lib/support/isInternalKey.js
@@ -1,4 +1,4 @@
-var unicodePrefix = require("./../internal/unicodePrefix");
+var privatePrefix = require("./../internal/privatePrefix");
 
 /**
  * Determined if the key passed in is an internal key.
@@ -9,6 +9,5 @@ var unicodePrefix = require("./../internal/unicodePrefix");
  */
 module.exports = function isInternalKey(x) {
     return x === "$size" ||
-        x === "$modelCreated" ||
-        x.charAt(0) === unicodePrefix;
+        x.substr(0, 2) === privatePrefix;
 };

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -55,7 +55,7 @@ module.exports = function mergeJSONGraphNode(
                 if (cType == null) {
                     // Has the branch been introduced to the cache yet? If not,
                     // give it a parent, key, and absolute path.
-                    if (node.ツparent == null) {
+                    if (node.$_parent == null) {
                         insertNode(node, parent, key, version, optimizedPath);
                     }
                     return node;
@@ -107,7 +107,7 @@ module.exports = function mergeJSONGraphNode(
                     // grandparents. If we've previously graphed this
                     // reference, break early. Otherwise, continue to
                     // leaf insertion below.
-                    if (node.ツparent != null) {
+                    if (node.$_parent != null) {
                         return node;
                     }
                 } else {
@@ -148,7 +148,7 @@ module.exports = function mergeJSONGraphNode(
         }
 
         if (mType && node === message) {
-            if (node.ツparent == null) {
+            if (node.$_parent == null) {
                 node = wrapNode(node, mType, node.value);
                 parent = updateNodeAncestors(parent, -node.$size, lru, version);
                 node = insertNode(node, parent, key, version, optimizedPath);

--- a/lib/support/removeNode.js
+++ b/lib/support/removeNode.js
@@ -14,6 +14,7 @@ module.exports = function removeNode(node, parent, key, lru) {
             splice(lru, node);
         }
         unlinkBackReferences(node);
+        // eslint-disable-next-line camelcase
         parent[key] = node.$_parent = void 0;
         return true;
     }

--- a/lib/support/removeNode.js
+++ b/lib/support/removeNode.js
@@ -14,7 +14,7 @@ module.exports = function removeNode(node, parent, key, lru) {
             splice(lru, node);
         }
         unlinkBackReferences(node);
-        parent[key] = node.ツparent = void 0;
+        parent[key] = node.$_parent = void 0;
         return true;
     }
     return false;

--- a/lib/support/removeNodeAndDescendants.js
+++ b/lib/support/removeNodeAndDescendants.js
@@ -1,12 +1,12 @@
 var hasOwn = require("./../support/hasOwn");
-var prefix = require("./../internal/unicodePrefix");
+var prefix = require("./../internal/reservedPrefix");
 var removeNode = require("./../support/removeNode");
 
 module.exports = function removeNodeAndDescendants(node, parent, key, lru) {
     if (removeNode(node, parent, key, lru)) {
         if (node.$type == null) {
             for (var key2 in node) {
-                if (key2[0] !== prefix && key2[0] !== "$" && hasOwn(node, key2)) {
+                if (key2[0] !== prefix && hasOwn(node, key2)) {
                     removeNodeAndDescendants(node[key2], node, key2, lru);
                 }
             }

--- a/lib/support/transferBackReferences.js
+++ b/lib/support/transferBackReferences.js
@@ -1,18 +1,23 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function transferBackReferences(fromNode, destNode) {
+    // eslint-disable-next-line camelcase
     var fromNodeRefsLength = fromNode.$_refsLength || 0,
+        // eslint-disable-next-line camelcase
         destNodeRefsLength = destNode.$_refsLength || 0,
         i = -1;
     while (++i < fromNodeRefsLength) {
         var ref = fromNode[__ref + i];
         if (ref !== void 0) {
+            // eslint-disable-next-line camelcase
             ref.$_context = destNode;
             destNode[__ref + (destNodeRefsLength + i)] = ref;
             fromNode[__ref + i] = void 0;
         }
     }
+    // eslint-disable-next-line camelcase
     destNode.$_refsLength = fromNodeRefsLength + destNodeRefsLength;
+    // eslint-disable-next-line camelcase
     fromNode.$_refsLength = void 0;
     return destNode;
 };

--- a/lib/support/transferBackReferences.js
+++ b/lib/support/transferBackReferences.js
@@ -1,18 +1,18 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function transferBackReferences(fromNode, destNode) {
-    var fromNodeRefsLength = fromNode.ツrefsLength || 0,
-        destNodeRefsLength = destNode.ツrefsLength || 0,
+    var fromNodeRefsLength = fromNode.$_refsLength || 0,
+        destNodeRefsLength = destNode.$_refsLength || 0,
         i = -1;
     while (++i < fromNodeRefsLength) {
         var ref = fromNode[__ref + i];
         if (ref !== void 0) {
-            ref.ツcontext = destNode;
+            ref.$_context = destNode;
             destNode[__ref + (destNodeRefsLength + i)] = ref;
             fromNode[__ref + i] = void 0;
         }
     }
-    destNode.ツrefsLength = fromNodeRefsLength + destNodeRefsLength;
-    fromNode.ツrefsLength = void 0;
+    destNode.$_refsLength = fromNodeRefsLength + destNodeRefsLength;
+    fromNode.$_refsLength = void 0;
     return destNode;
 };

--- a/lib/support/unlinkBackReferences.js
+++ b/lib/support/unlinkBackReferences.js
@@ -1,13 +1,13 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function unlinkBackReferences(node) {
-    var i = -1, n = node.ツrefsLength || 0;
+    var i = -1, n = node.$_refsLength || 0;
     while (++i < n) {
         var ref = node[__ref + i];
         if (ref != null) {
-            ref.ツcontext = ref.ツrefIndex = node[__ref + i] = void 0;
+            ref.$_context = ref.$_refIndex = node[__ref + i] = void 0;
         }
     }
-    node.ツrefsLength = void 0;
+    node.$_refsLength = void 0;
     return node;
 };

--- a/lib/support/unlinkBackReferences.js
+++ b/lib/support/unlinkBackReferences.js
@@ -1,13 +1,16 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function unlinkBackReferences(node) {
+    // eslint-disable-next-line camelcase
     var i = -1, n = node.$_refsLength || 0;
     while (++i < n) {
         var ref = node[__ref + i];
         if (ref != null) {
+            // eslint-disable-next-line camelcase
             ref.$_context = ref.$_refIndex = node[__ref + i] = void 0;
         }
     }
+    // eslint-disable-next-line camelcase
     node.$_refsLength = void 0;
     return node;
 };

--- a/lib/support/unlinkForwardReference.js
+++ b/lib/support/unlinkForwardReference.js
@@ -1,14 +1,19 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function unlinkForwardReference(reference) {
+    // eslint-disable-next-line camelcase
     var destination = reference.$_context;
     if (destination) {
+        // eslint-disable-next-line camelcase
         var i = (reference.$_refIndex || 0) - 1,
+            // eslint-disable-next-line camelcase
             n = (destination.$_refsLength || 0) - 1;
         while (++i <= n) {
             destination[__ref + i] = destination[__ref + (i + 1)];
         }
+        // eslint-disable-next-line camelcase
         destination.$_refsLength = n;
+        // eslint-disable-next-line camelcase
         reference.$_refIndex = reference.$_context = destination = void 0;
     }
     return reference;

--- a/lib/support/unlinkForwardReference.js
+++ b/lib/support/unlinkForwardReference.js
@@ -1,15 +1,15 @@
 var __ref = require("./../internal/ref");
 
 module.exports = function unlinkForwardReference(reference) {
-    var destination = reference.ツcontext;
+    var destination = reference.$_context;
     if (destination) {
-        var i = (reference.ツrefIndex || 0) - 1,
-            n = (destination.ツrefsLength || 0) - 1;
+        var i = (reference.$_refIndex || 0) - 1,
+            n = (destination.$_refsLength || 0) - 1;
         while (++i <= n) {
             destination[__ref + i] = destination[__ref + (i + 1)];
         }
-        destination.ツrefsLength = n;
-        reference.ツrefIndex = reference.ツcontext = destination = void 0;
+        destination.$_refsLength = n;
+        reference.$_refIndex = reference.$_context = destination = void 0;
     }
     return reference;
 };

--- a/lib/support/updateBackReferenceVersions.js
+++ b/lib/support/updateBackReferenceVersions.js
@@ -5,11 +5,11 @@ module.exports = function updateBackReferenceVersions(nodeArg, version) {
     var count = 0;
     do {
         var node = stack[count];
-        if (node && node.ツversion !== version) {
-            node.ツversion = version;
-            stack[count++] = node.ツparent;
+        if (node && node.$_version !== version) {
+            node.$_version = version;
+            stack[count++] = node.$_parent;
             var i = -1;
-            var n = node.ツrefsLength || 0;
+            var n = node.$_refsLength || 0;
             while (++i < n) {
                 stack[count++] = node[__ref + i];
             }

--- a/lib/support/updateBackReferenceVersions.js
+++ b/lib/support/updateBackReferenceVersions.js
@@ -5,10 +5,14 @@ module.exports = function updateBackReferenceVersions(nodeArg, version) {
     var count = 0;
     do {
         var node = stack[count];
+        // eslint-disable-next-line camelcase
         if (node && node.$_version !== version) {
+            // eslint-disable-next-line camelcase
             node.$_version = version;
+            // eslint-disable-next-line camelcase
             stack[count++] = node.$_parent;
             var i = -1;
+            // eslint-disable-next-line camelcase
             var n = node.$_refsLength || 0;
             while (++i < n) {
                 stack[count++] = node[__ref + i];

--- a/lib/support/updateNodeAncestors.js
+++ b/lib/support/updateNodeAncestors.js
@@ -4,11 +4,11 @@ var updateBackReferenceVersions = require("./../support/updateBackReferenceVersi
 module.exports = function updateNodeAncestors(nodeArg, offset, lru, version) {
     var child = nodeArg;
     do {
-        var node = child.ツparent;
+        var node = child.$_parent;
         var size = child.$size = (child.$size || 0) - offset;
         if (size <= 0 && node != null) {
-            removeNode(child, node, child.ツkey, lru);
-        } else if (child.ツversion !== version) {
+            removeNode(child, node, child.$_key, lru);
+        } else if (child.$_version !== version) {
             updateBackReferenceVersions(child, version);
         }
         child = node;

--- a/lib/support/wrapNode.js
+++ b/lib/support/wrapNode.js
@@ -34,7 +34,7 @@ module.exports = function wrapNode(nodeArg, typeArg, value) {
             $_prev: undefined,
             // eslint-disable-next-line camelcase
             $_next: undefined,
-            // eslint-disable-next-line camelcase            
+            // eslint-disable-next-line camelcase
             $_modelCreated: true
         };
     }

--- a/lib/support/wrapNode.js
+++ b/lib/support/wrapNode.js
@@ -20,15 +20,21 @@ module.exports = function wrapNode(nodeArg, typeArg, value) {
         node = clone(node);
         size = getSize(node);
         node.$type = type;
+        // eslint-disable-next-line camelcase
         node.$_prev = undefined;
+        // eslint-disable-next-line camelcase
         node.$_next = undefined;
+        // eslint-disable-next-line camelcase
         node.$_modelCreated = modelCreated || false;
     } else {
         node = {
             $type: atomType,
             value: value,
+            // eslint-disable-next-line camelcase
             $_prev: undefined,
+            // eslint-disable-next-line camelcase
             $_next: undefined,
+            // eslint-disable-next-line camelcase            
             $_modelCreated: true
         };
     }

--- a/lib/support/wrapNode.js
+++ b/lib/support/wrapNode.js
@@ -16,20 +16,20 @@ module.exports = function wrapNode(nodeArg, typeArg, value) {
     var type = typeArg;
 
     if (type) {
-        var modelCreated = node.ツmodelCreated;
+        var modelCreated = node.$_modelCreated;
         node = clone(node);
         size = getSize(node);
         node.$type = type;
-        node.ツprev = undefined;
-        node.ツnext = undefined;
-        node.ツmodelCreated = modelCreated || false;
+        node.$_prev = undefined;
+        node.$_next = undefined;
+        node.$_modelCreated = modelCreated || false;
     } else {
         node = {
             $type: atomType,
             value: value,
-            ツprev: undefined,
-            ツnext: undefined,
-            ツmodelCreated: true
+            $_prev: undefined,
+            $_next: undefined,
+            $_modelCreated: true
         };
     }
 

--- a/test/set/support/strip.js
+++ b/test/set/support/strip.js
@@ -1,6 +1,6 @@
 var isArray = Array.isArray;
 var slice = Array.prototype.slice;
-var __unicodePrefix = require("../../../lib/internal/unicodePrefix");
+var __reservedPrefix = require("../../../lib/internal/reservedPrefix");
 
 module.exports = function strip(cache, allowedKeys) {
     if (cache == null || typeof cache !== "object") {
@@ -16,8 +16,7 @@ module.exports = function strip(cache, allowedKeys) {
                 if (val === void 0) {
                     return obj;
                 } else if (
-                    key[0] !== __unicodePrefix &&
-                    key[0] !== "$"      ||
+                    key[0] !== __reservedPrefix ||
                     ~allowedKeys.indexOf(key)) {
                     obj[key] = strip(cache[key], allowedKeys);
                 }


### PR DESCRIPTION
Falcor used to use the smiley face unicode character for private members which we placed on objects we returned to users and for bookkeeping information on cache objects. The intention was to avoid conflicting with user input, but the unicode characters wreaked havoc on a variety of tools.

With this change we've decided to reserve the "$" keyspace. When inserting user input which may start with '$' into a path, the input should be encoded. The following code...

```js
async function run() {
  await {json} = await model.get(["search", input, {from:0,to:10}, "name"]);
  console.log(json.search[input][0].name);
}
```

...must be rewritten like this...

```js
async function run() {
  let escapedInput = escape(input);
  await {json} = await model.get(["search", escapedInput, {from:0,to:10}, "name"]);
  console.log(json.search[escapedInput][0].name);
}
```