### PR TITLE
adding maxRetries option to Model Constructor

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -65,6 +65,7 @@ Model.pathValue = jsong.pathValue;
  * @param {?DataSource} options.source - a data source to retrieve and manage the {@link JSONGraph}
  * @param {?JSONGraph} options.cache - initial state of the {@link JSONGraph}
  * @param {?number} options.maxSize - the maximum size of the cache. This value roughly correlates to item count (where itemCount = maxSize / 50). Each item by default is given a metadata `$size` of 50 (or its length when it's an array or string). You can get better control of falcor's memory usage by tweaking `$size`
+ * @param {?number} options.maxRetries - the maximum number of times that the Model will attempt to retrieve the value from the server.
  * @param {?number} options.collectRatio - the ratio of the maximum size to collect when the maxSize is exceeded
  * @param {?Model~errorSelector} options.errorSelector - a function used to translate errors before they are returned
  * @param {?Model~onChange} options.onChange - a function called whenever the Model's cache is changed
@@ -84,6 +85,12 @@ function Model(o) {
         this._maxSize = options.maxSize;
     } else {
         this._maxSize = options._maxSize || Model.prototype._maxSize;
+    }
+
+    if (typeof options.maxRetries === "number") {
+        this._maxRetries = options.maxRetries;
+    } else {
+        this._maxRetries = options.maxRetries || Model.prototype._maxRetries;
     }
 
     if (typeof options.collectRatio === "number") {
@@ -121,6 +128,7 @@ Model.prototype._boxed = false;
 Model.prototype._progressive = false;
 Model.prototype._treatErrorsAsValues = false;
 Model.prototype._maxSize = Math.pow(2, 53) - 1;
+Model.prototype._maxRetries = 3;
 Model.prototype._collectRatio = 0.75;
 
 /**

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -22,8 +22,11 @@ var InvalidSourceError = require("../../errors/InvalidSourceError");
 module.exports = function getRequestCycle(getResponse, model, results, observer,
                                           errors, count) {
     // we have exceeded the maximum retry limit.
-    if (count === 10) {
-        throw new MaxRetryExceededError();
+    if (count === model._maxRetries) {
+        observer.onError(new MaxRetryExceededError());
+        return {
+            dispose: function() {}
+        };
     }
 
     var requestQueue = model._request;

--- a/lib/response/set/setRequestCycle.js
+++ b/lib/response/set/setRequestCycle.js
@@ -13,8 +13,11 @@ var MaxRetryExceededError = require("./../../errors/MaxRetryExceededError");
 module.exports = function setRequestCycle(model, observer, groups,
                                           isJSONGraph, isProgressive, count) {
     // we have exceeded the maximum retry limit.
-    if (count === 10) {
-        throw new MaxRetryExceededError();
+    if (count === model._maxRetries) {
+        observer.onError(new MaxRetryExceededError());
+        return {
+            dispose: function() {}
+        };
     }
 
     var requestedAndOptimizedPaths = setGroupsIntoCache(model, groups);

--- a/test/data/asyncifyDataSource.js
+++ b/test/data/asyncifyDataSource.js
@@ -1,0 +1,13 @@
+var Rx = require("rx");
+
+module.exports = function asyncifyDataSource(ds) {
+    var outputDataSource = {};
+    ["get", "set", "call"].forEach(function(method) {
+        outputDataSource[method] = function() {
+            var args = Array.prototype.slice.call(arguments);
+            return ds[method].apply(ds, args).observeOn(Rx.Scheduler.timeout);
+        };
+    });
+
+    return outputDataSource;
+};


### PR DESCRIPTION
Fixing bug in which MaxRetriesExceededErrror is thrown rather than sent to observer's onError method. Previously, this error was thrown after 10 failed attempts to retrieve a value from the DataSource. Now, the number of retries can be configured by including a `maxRetries` field on the options object accepted by the Model constructor:

```js
let model = new falcor.Model({ maxRetries: 5 }); 
```

The new default value of `maxRetries` is 3 instead of 10.