### PR TITLE
Always onNext if any value discovered in cache

### DIFF
--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -113,12 +113,14 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
             curr = curr[k];
         }
         k = requestedPath[i];
-        if (k !== null) {
-            curr[k] = valueNode;
-        } else {
-            // We are protected from reaching here when depth is 1 and prev is
-            // undefined by the InvalidModelError and NullInPathError checks.
-            prev[prevK] = valueNode;
+        if (valueNode !== undefined) {
+          if (k !== null) {
+              curr[k] = valueNode;
+          } else {
+              // We are protected from reaching here when depth is 1 and prev is
+              // undefined by the InvalidModelError and NullInPathError checks.
+              prev[prevK] = valueNode;
+          }
         }
     }
 };

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -17,7 +17,6 @@ module.exports = function onValueType(
     requestedPath, optimizedPath, optimizedLength, isJSONG, fromReference) {
 
     var currType = node && node.$type;
-    var requiresMaterializedToReport = node && node.value === undefined;
 
     // There are is nothing here, ether report value, or report the value
     // that is missing.  If there is no type then report the missing value.
@@ -65,13 +64,7 @@ module.exports = function onValueType(
             requestedPath[depth] = null;
             depth += 1;
         }
-
-        if (!requiresMaterializedToReport ||
-            requiresMaterializedToReport && model._materialized) {
-
-            onValue(model, node, seed, depth, outerResults, branchInfo,
-                    requestedPath, optimizedPath, optimizedLength, isJSONG);
-        }
+        onValue(model, node, seed, depth, outerResults, branchInfo,
+                requestedPath, optimizedPath, optimizedLength, isJSONG);
     }
 };
-

--- a/test/falcor/get/get.dataSource-and-cache.spec.js
+++ b/test/falcor/get/get.dataSource-and-cache.spec.js
@@ -18,6 +18,46 @@ var Cache = function(c) {
 };
 
 describe('DataSource and Partial Cache', function() {
+    it('should onNext only once even if a subset of the requested values is found in the cache', function(done) {
+        var model = new Model({
+            cache: {
+                paths: {
+                    0: 'test',
+                    1: 'test'
+                }
+            },
+            source: new LocalDataSource({
+                paths: {
+                    2: Model.atom('test'),
+                    3: Model.atom(undefined)
+                }
+            }, {materialize: true})
+        });
+
+        var onNextCount = 0;
+        toObservable(model.
+            get(['paths', {to:3}])).
+            doAction(function(value) {
+
+                onNextCount++;
+
+                if (onNextCount === 1){
+                    expect(strip(value)).to.deep.equals({
+                        json: {
+                            paths: {
+                                0: 'test',
+                                1: 'test',
+                                2: 'test'
+                            }
+                        }
+                    });
+                }
+            }).subscribe(noOp, done, function(){
+                expect(onNextCount, 'onNext called once').to.equals(1);
+                done();
+            });
+    });
+
     describe('Preload Functions', function() {
         it('should get multiple arguments with multiple selector function args.', function(done) {
             var model = new Model({cache: M(), source: new LocalDataSource(Cache())});
@@ -266,6 +306,8 @@ describe('DataSource and Partial Cache', function() {
                 subscribe(noOp, done, done);
         });
     });
+
+
     describe('_toJSONG', function() {
         it('should get multiple arguments into a single _toJSONG response.', function(done) {
             var model = new Model({cache: M(), source: new LocalDataSource(Cache())});
@@ -306,6 +348,56 @@ describe('DataSource and Partial Cache', function() {
         });
     });
     describe('Progressively', function() {
+        it('should onNext twice if at least one value found in the cache - even if it is an atom of undefined', function(done) {
+            var model = new Model({
+                cache: {
+                    paths: {
+                        0: 'test',
+                        1: 'test'
+                    }
+                },
+                source: new LocalDataSource({
+                    paths: {
+                        2: Model.atom('test'),
+                        3: Model.atom(undefined)
+                    }
+                }, {materialize: true})
+            });
+
+            var onNextCount = 0;
+            toObservable(model.
+                get(['paths', {to:3}]).
+                progressively()).
+                doAction(function(value) {
+
+                    onNextCount++;
+                    if (onNextCount === 1){
+                        expect(strip(value)).to.deep.equals({
+                            json: {
+                                paths: {
+                                    0: 'test',
+                                    1: 'test'
+                                }
+                            }
+                        });
+                    }
+                    else if (onNextCount === 2){
+                        expect(strip(value)).to.deep.equals({
+                            json: {
+                                paths: {
+                                    0: 'test',
+                                    1: 'test',
+                                    2: 'test'
+                                }
+                            }
+                        });
+                    }
+                }).subscribe(noOp, done, function(){
+                    expect(onNextCount, 'onNext called twice').to.equals(2);
+                    done();
+                });
+        });
+
         it('should get multiple arguments with multiple trips to the dataSource into a single toJSON response.', function(done) {
             var model = new Model({cache: M(), source: new LocalDataSource(Cache())});
             var count = 0;
@@ -703,4 +795,3 @@ describe('DataSource and Partial Cache', function() {
         });
     });
 });
-

--- a/test/get-core/edges.spec.js
+++ b/test/get-core/edges.spec.js
@@ -18,10 +18,12 @@ describe('Edges', function() {
             cache: cacheGenerator(0, 1)
         });
     });
-    it('should not report an atom of undefined in non-materialize mode.', function() {
+    it('should report an atom of undefined in non-progressive mode.', function() {
         getCoreRunner({
             input: [['videos']],
-            output: { },
+            output: {
+                json: {}
+            },
             cache: {
                 videos: atom(undefined)
             }
@@ -117,4 +119,3 @@ describe('Edges', function() {
         });
     });
 });
-

--- a/test/integration/call.spec.js
+++ b/test/integration/call.spec.js
@@ -80,7 +80,7 @@ describe('call', function() {
         toObservable(model.
             call("genreList[0].titles.push", args, ['name'])).
             doAction(onNext, noOp, function() {
-                expect(onNext.callCount).to.equal(0);
+                expect(onNext.callCount).to.equal(1);
             }).
             subscribe(noOp, done, done);
     });
@@ -118,4 +118,3 @@ describe('call', function() {
             });
     });
 });
-


### PR DESCRIPTION
Up until this PR, Falcor would not notify if none of the requested values were found in the DataSource. Consequently in some circumstances onNext would not fire. This was unergonomic as this unpredictability forced developers to register an onCompleted handler in addition to the onNext if they wanted to perform clean up tasks. It also meant that sometimes Promises never resolved. 

With this PR, Falcor will onNext even if none of the requested values exist in the DataSource. In progressive mode, it will continue to onNext immediately if at least one of the requested values is present in the cache. However this PR will also cause it to onNext if any requested value is **known to be undefined** (i.e. an atom of undefined is used to store this info in the cache). 

In other words it is now possible to be onNext'ed a JSON object which contains no data (i.e. all requested values are undefined) even if you are not in progressive mode. This is a breaking change which will require more defensive coding if your app currently assumes that onNext will only be called when at least one requested value is defined in the DataSource. However most apps already must account for the possibility that any of a set of requested  values may be undefined, so I believe the impact of this change will be low.

One thing worth noting: if you are in progressive mode and the cache contains none of the requested values, and none of the requested values are known to be undefined, onNext will not fire initially. It is likely that we will force a call to onNext in this case as well in the future. 