### PR TITLE
No longer creating Path-bound errors for DataSource errors

### DIFF
--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -3,10 +3,7 @@ var flushGetRequest = require("./flushGetRequest");
 var REQUEST_ID = 0;
 var GetRequestType = require("./RequestTypes").GetRequest;
 var setJSONGraphs = require("./../set/setJSONGraphs");
-var setPathValues = require("./../set/setPathValues");
-var $error = require("./../types/error");
 var emptyArray = [];
-var InvalidSourceError = require("./../errors/InvalidSourceError");
 
 /**
  * Creates a new GetRequest.  This GetRequest takes a scheduler and
@@ -70,7 +67,7 @@ GetRequestV2.prototype = {
                         self.requestQueue.removeRequest(self);
                         self._disposed = true;
 
-                        if (err instanceof InvalidSourceError) {
+                        if (err) {
                             for (i = 0, len = callbacks.length; i < len; ++i) {
                                 fn = callbacks[i];
                                 if (fn) {
@@ -169,42 +166,10 @@ GetRequestV2.prototype = {
         // flatten all the requested paths, adds them to the
         var nextPaths = flattenRequestedPaths(requested);
 
-        // Insert errors in every requested position.
-        if (err) {
-            var error = err;
-
-            // Converts errors to objects, a more friendly storage
-            // of errors.
-            if (error instanceof Error) {
-                error = {
-                    message: error.message
-                };
-            }
-
-            // Not all errors are value $types.
-            if (!error.$type) {
-                error = {
-                    $type: $error,
-                    value: error
-                };
-            }
-
-            var pathValues = nextPaths.map(function(x) {
-                return {
-                    path: x,
-                    value: error
-                };
-            });
-            setPathValues(model, pathValues, null, errorSelector, comparator);
-        }
-
-        // Insert the jsonGraph from the dataSource.
-        else {
-            setJSONGraphs(model, [{
-                paths: nextPaths,
-                jsonGraph: data.jsonGraph
-            }], null, errorSelector, comparator);
-        }
+        setJSONGraphs(model, [{
+            paths: nextPaths,
+            jsonGraph: data.jsonGraph
+        }], null, errorSelector, comparator);
 
         // return the model"s boundPath
         model._path = boundPath;

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -4,7 +4,6 @@ var fastCat = require("./../../get/util/support").fastCat;
 var collectLru = require("./../../lru/collect");
 var getSize = require("./../../support/getSize");
 var AssignableDisposable = require("./../AssignableDisposable");
-var InvalidSourceError = require("../../errors/InvalidSourceError");
 
 /**
  * The get request cycle for checking the cache and reporting
@@ -53,7 +52,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
     var currentRequestDisposable = requestQueue.
         get(boundRequestedMissingPaths, optimizedMissingPaths, function(err) {
 
-            if (err instanceof InvalidSourceError) {
+            if (err) {
                 observer.onError(err);
                 return;
             }

--- a/test/falcor/error/index.js
+++ b/test/falcor/error/index.js
@@ -18,19 +18,16 @@ describe("Error", function() {
         toObservable(model.
             get(["test", {to: 5}, "summary"])).
             doAction(noOp, function(err) {
-                expect(err.length).to.equal(6);
                 // not in boxValue mode
                 var expected = {
-                    path: [],
+                    $type: "error",
                     value: {
                         status: 503,
                         message: "Timeout"
                     }
                 };
-                err.forEach(function(e, i) {
-                    expected.path = ["test", i, "summary"];
-                    expect(e).to.deep.equals(expected);
-                });
+
+                expect(err).to.deep.equals(expected);
             }).
             subscribe(function() {
                 done('Should not onNext');
@@ -66,8 +63,8 @@ describe("Error", function() {
             get(["test", {to: 5}, "summary"])).
             doAction(onNext, function(err) {
 
-                // Ensure onNext is called correctly
-                expect(onNext.calledOnce, 'onNext called').to.be.ok;
+                // Ensure onNext is not called
+                expect(onNext.callCount, 'onNext called').to.equal(0);
                 expect(clean(onNext.getCall(0).args[0]), 'json from onNext').to.deep.equals({
                     json: {
                         test: {
@@ -77,19 +74,15 @@ describe("Error", function() {
                     }
                 });
 
-                expect(err.length).to.equal(4);
                 // not in boxValue mode
                 var expected = {
-                    path: [],
+                    $type: "error",
                     value: {
                         status: 503,
                         message: "Timeout"
                     }
                 };
-                err.forEach(function(e, i) {
-                    expected.path = ["test", i + 1, "summary"];
-                    expect(e).to.deep.equals(expected);
-                });
+                expect(err).to.deep.equals(expected);
             }).
             subscribe(noOp, doneOnError(done), errorOnCompleted(done));
     });

--- a/test/falcor/get/get.cacheAsDataSource.spec.js
+++ b/test/falcor/get/get.cacheAsDataSource.spec.js
@@ -66,6 +66,7 @@ describe('Cache as DataSource', function() {
         });
     });
     it('should report errors from a dataSource.', function(done) {
+        var outputError;
         var model = new Model({
             source: new Model({
                 source: new ErrorDataSource(500, 'Oops!')
@@ -74,17 +75,18 @@ describe('Cache as DataSource', function() {
         toObservable(model.
             get(['videos', 1234, 'summary'])).
             doAction(noOp, function(err) {
-                expect(err).to.deep.equals([{
-                    path: ['videos', 1234, 'summary'],
+                outputError = err;
+                expect(err).to.deep.equals({
+                    $type: "error",
                     value: {
                         message: 'Oops!',
                         status: 500
                     }
-                }]);
+                });
             }).
             subscribe(noOp, function(err) {
                 // ensure its the same error
-                if (Array.isArray(err) && isPathValue(err[0])) {
+                if (outputError === err) {
                     done();
                 } else {
                     done(err);
@@ -149,4 +151,3 @@ describe('Cache as DataSource', function() {
             subscribe(noOp, done, done);
     });
 });
-

--- a/test/falcor/get/get.dataSource-only.spec.js
+++ b/test/falcor/get/get.dataSource-only.spec.js
@@ -135,29 +135,32 @@ describe('DataSource Only', function() {
         });
     });
     it('should report errors from a dataSource.', function(done) {
+        var outputError = null;
         var model = new Model({
             source: new ErrorDataSource(500, 'Oops!')
         });
         toObservable(model.
             get(['videos', 0, 'title'])).
             doAction(noOp, function(err) {
-                expect(err).to.deep.equals([{
-                    path: ['videos', 0, 'title'],
+                outputError = err;
+                expect(err).to.deep.equals({
+                    $type: "error",
                     value: {
                         message: 'Oops!',
                         status: 500
                     }
-                }]);
+                });
             }, function() {
                 throw new Error('On Completed was called. ' +
                      'OnError should have been called.');
             }).
             subscribe(noOp, function(err) {
-                // ensure its the same error
-                if (Array.isArray(err) && isPathValue(err[0])) {
+                if (err === outputError) {
                     return done();
                 }
-                return done(err);
+                else {
+                    return done(err);
+                }
             });
     });
     it("should get all missing paths in a single request", function(done) {

--- a/test/lru/lru.splice.expired.spec.js
+++ b/test/lru/lru.splice.expired.spec.js
@@ -31,7 +31,6 @@ describe('Expired', function() {
         Rx.Observable.
             timer(100).
             flatMap(function() {
-                debugger
                 return model.get(['expireSoon', 'summary']);
             }).
             doAction(onNext, noOp, function() {
@@ -43,4 +42,3 @@ describe('Expired', function() {
             subscribe(noOp, done, done);
     });
 });
-


### PR DESCRIPTION
**BREAKING CHANGE**: Model no longer creates path-bound errors when DataSource onErrors

In the current Master HEAD if a DataSource's Observable onError's, the Falcor Model will create a path-bound error for every requested path, and insert a JSON Graph error object at each requested path in the Model cache. **The problem with this approach to error handling is that it can create the false impression that objects exist which do not exist.**

As an example, the code below attempts to retrieve two paths from a DataSource which always onErrors.

```js
import { Observable } from "rx"
const FailingDataSource = { 
  get() { return Observable.error({ message: "FAIL" }); }
};

async function test() {
  const model = new falcor.Model({ source: FailingDataSource }):
  try {
    await model.get(["videos", [123,456], "name"]);
  }
  catch(errors) {
    console.log(errors);
  }
}

test();
```

The Falcor Model creates an error for each requested path. As a result, the following array is onError'ed and printed to the console:
```
[
  { path: ["videos", 123, "name"], value: { message: "FAIL" } },
  { path: ["videos", 456, "name"], value: { message: "FAIL" } }
]
```

Furthermore the Model inserts JSON Graph error objects into the cache at each requested path.  This is the state of the Model cache after the code above executes:

```
{
  videos: {
    123: {
      name: { $type: "error", value: { message: "FAIL" } }
    },
    456: {
      name: { $type: "error", value: { message: "FAIL" } }
    }
  }
}
```
Note that placing a JSON Graph error at ["videos", 123, "name"] and ["videos", 456, "name"] respectively creates the impression that **both ["videos", 123] and ["videos", 456] exist**. This is __not__ necessarily true, bearing in mind that a DataSource error can be caused by things as innocuous as a timeout.

This PR halts the practice of creating JSON Graph errors for DataSource errors sent via a DataSource notification. The new behavior is that Model's will simply forward errors sent from DataSources as Promise rejections or Observable onError notifications. After this PR the code example above will produce the following console output:

```
// logged rejection from Model Promise
{ message: "FAIL" }
```

Furthermore no further data will be written into the Falcor cache when a Model recieves a DataSource error.

This is a **breaking change**, because the shape of error objects that come out of ModelResponses will change. Instead of the Model onError'ing an Array of errors wrapped in path-bound values, the Model will simply onError the error that comes out of the DataSource.