### PR TITLE
Omit references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 *.tar.gz
 cTestFinal.js
 npm-debug.log
+.vscode

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -34,6 +34,11 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         valueNode = clone(node);
     }
 
+    // We don't want to emit references in json output
+    else if (!isJSONG && node.$type === $ref) {
+        valueNode = undefined;
+    }
+
     // JSONG always clones the node.
     else if (node.$type === $ref || node.$type === $error) {
         if (isJSONG) {

--- a/test/get-core/references.spec.js
+++ b/test/get-core/references.spec.js
@@ -59,7 +59,7 @@ describe('References', function() {
             input: [['circular', 'title']],
             output: {
                 json: {
-                    circular: ['circular', 'next']
+                    circular: {}
                 }
             },
             cache: referenceCache

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -152,34 +152,41 @@ describe('Values', function() {
             }
         });
     });
-    it('should not clobber values with intersecting paths.', function() {
-        getCoreRunner({
-            input: [['lists', 2343, '0', 'name'], ['lists', 2343, '0']],
-            output: {
-                json: {
-                    lists: {
-                        2343: {
-                            0: {
-                                name: 'House of cards'
+
+    function intersectingTest(paths) {
+        return function() {
+            getCoreRunner({
+                input: paths,
+                output: {
+                    json: {
+                        lists: {
+                            2343: {
+                                0: {
+                                    name: 'House of cards'
+                                }
                             }
                         }
                     }
-                }
-            },
-            cache: {
-                lists: {
-                    2343: {
-                        0: jsonGraph.ref(["videos", 123])
-                    }
                 },
-                videos: {
-                    123: {
-                        name: atom("House of cards")
+                cache: {
+                    lists: {
+                        2343: {
+                            0: jsonGraph.ref(["videos", 123])
+                        }
+                    },
+                    videos: {
+                        123: {
+                            name: atom("House of cards")
+                        }
                     }
                 }
-            }
-        });
-    });
+            });
+        };
+    }
+
+    it('should not clobber values with intersecting paths.', intersectingTest([['lists', 2343, '0', 'name'], ['lists', 2343, '0']]));
+    it('should not clobber values with intersecting paths reversed.', intersectingTest([['lists', 2343, '0'], ['lists', 2343, '0', 'name']]));
+
     it('should have no output for empty paths.', function() {
         getCoreRunner({
             input: [['lolomo', 0, [], 'item', 'title']],

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -117,14 +117,65 @@ describe('Values', function() {
         getCoreRunner({
             input: [['lolomo']],
             output: {
-                json: {
-                    lolomo: ['test', 'value']
-                }
+                json: {}
             },
             cache: {
                 lolomo: jsonGraph.ref(['test', 'value']),
                 test: {
                     value: atom('value')
+                }
+            }
+        });
+    });
+    it('should not get references.', function() {
+        getCoreRunner({
+            input: [["lists", 2343, "0"]],
+            output: {
+                json: {
+                    lists: {
+                        2343: {
+                        }
+                    }
+                }
+            },
+            cache: {
+                lists: {
+                    2343: {
+                        0: jsonGraph.ref(["videos", 123])
+                    }
+                },
+                videos: {
+                    123: {
+                        name: atom("House of cards")
+                    }
+                }
+            }
+        });
+    });
+    it('should not clobber values with intersecting paths.', function() {
+        getCoreRunner({
+            input: [['lists', 2343, '0', 'name'], ['lists', 2343, '0']],
+            output: {
+                json: {
+                    lists: {
+                        2343: {
+                            0: {
+                                name: 'House of cards'
+                            }
+                        }
+                    }
+                }
+            },
+            cache: {
+                lists: {
+                    2343: {
+                        0: jsonGraph.ref(["videos", 123])
+                    }
+                },
+                videos: {
+                    123: {
+                        name: atom("House of cards")
+                    }
                 }
             }
         });

--- a/test/getCoreRunner.js
+++ b/test/getCoreRunner.js
@@ -86,8 +86,8 @@ module.exports = function(testConfig) {
     // $size is stripped out of basic core tests.
     // We have to strip out parent as well from the output since it will produce
     // infinite recursion.
-    clean(valueNode, {strip: ['$size']});
-    clean(expectedOutput, {strip: ['$size']});
+    clean(valueNode, {strip: ['$size', '$__path']});
+    clean(expectedOutput, {strip: ['$size', '$__path']});
 
     if (expectedOutput) {
         expect(valueNode).to.deep.equals(expectedOutput);


### PR DESCRIPTION
Previously, model.get(['a', 'b']) where b is a reference would result in references in the json output. This change instead results in emitting nothing where a reference would previously exist. JSONG remains unchanged.