### PR TITLE
Always onnext

### DIFF
--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -24,7 +24,7 @@ function mergeInto(target, obj) {
 }
 
 function defaultEnvelope(isJSONG) {
-    return isJSONG ? {jsonGraph: {}} : {json: {}};
+    return isJSONG ? {jsonGraph: {}, paths: []} : {json: {}};
 }
 
 module.exports = function get(walk, isJSONG) {

--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -89,7 +89,7 @@ module.exports = function get(walk, isJSONG) {
         // Merge in existing results.
         // Default to empty envelope if no results were emitted
         mergeInto(valueNode, paths.length ? seed[0] : defaultEnvelope(isJSONG));
-        
+
         return results;
     };
 };

--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -23,6 +23,10 @@ function mergeInto(target, obj) {
     }
 }
 
+function defaultEnvelope(isJSONG) {
+    return isJSONG ? {jsonGraph: {}} : {json: {}};
+}
+
 module.exports = function get(walk, isJSONG) {
     return function innerGet(model, paths, seed) {
         // Result valueNode not immutable for isJSONG.
@@ -83,8 +87,9 @@ module.exports = function get(walk, isJSONG) {
         }
 
         // Merge in existing results.
-        mergeInto(valueNode, seed[0]);
-
+        // Default to empty envelope if no results were emitted
+        mergeInto(valueNode, paths.length ? seed[0] : defaultEnvelope(isJSONG));
+        
         return results;
     };
 };

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -18,7 +18,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     }
 
     var i, len, k, key, curr, prev = null, prevK;
-    var materialized = false, valueNode;
+    var materialized = false, valueNode, nodeType = node && node.$type, nodeValue = node && node.value;
 
     if (!node || node.value === undefined) {
         materialized = model._materialized;
@@ -35,31 +35,31 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     }
 
     // We don't want to emit references in json output
-    else if (!isJSONG && node.$type === $ref) {
+    else if (!isJSONG && nodeType === $ref) {
         valueNode = undefined;
     }
 
     // JSONG always clones the node.
-    else if (node.$type === $ref || node.$type === $error) {
+    else if (nodeType === $ref || nodeType === $error) {
         if (isJSONG) {
             valueNode = clone(node);
         } else {
-            valueNode = node.value;
+            valueNode = nodeValue;
         }
     }
 
     else if (isJSONG) {
-        var isObject = node.value && typeof node.value === "object";
-        var isUserCreatedNode = !node.$_modelCreated;
+        var isObject = nodeValue && typeof nodeValue === "object";
+        var isUserCreatedNode = !node || !node.$_modelCreated;
         if (isObject || isUserCreatedNode) {
             valueNode = clone(node);
         } else {
-            valueNode = node.value;
+            valueNode = nodeValue;
         }
     }
 
     else {
-        valueNode = node.value;
+        valueNode = nodeValue;
     }
 
     if (outerResults) {

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -20,6 +20,10 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     var i, len, k, key, curr, prev = null, prevK;
     var materialized = false, valueNode, nodeType = node && node.$type, nodeValue = node && node.value;
 
+    if (outerResults && node && nodeType !== $error) {
+        outerResults.hasValues = true;
+    }
+
     if (!node || node.value === undefined) {
         materialized = model._materialized;
     }

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -20,10 +20,6 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     var i, len, k, key, curr, prev = null, prevK;
     var materialized = false, valueNode, nodeType = node && node.$type, nodeValue = node && node.value;
 
-    if (outerResults && node && nodeType !== $error) {
-        outerResults.hasValues = true;
-    }
-
     if (!node || node.value === undefined) {
         materialized = model._materialized;
     }
@@ -66,9 +62,12 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         valueNode = nodeValue;
     }
 
+    var hasValues = false;
+
     if (isJSONG) {
         curr = seed.jsonGraph;
         if (!curr) {
+            hasValues = true;
             curr = seed.jsonGraph = {};
             seed.paths = [];
         }
@@ -76,6 +75,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
             key = optimizedPath[i];
 
             if (!curr[key]) {
+                hasValues = true;
                 curr[key] = {};
             }
             curr = curr[key];
@@ -94,6 +94,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     // The output is pathMap and the depth is 0.  It is just a
     // value report it as the found JSON
     else if (depth === 0) {
+        hasValues = true;
         seed.json = valueNode;
     }
 
@@ -102,6 +103,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
     else {
         curr = seed.json;
         if (!curr) {
+            hasValues = true;
             curr = seed.json = {};
         }
         for (i = 0; i < depth - 1; i++) {
@@ -110,6 +112,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
             // The branch info is already generated output from the walk algo
             // with the required __path information on it.
             if (!curr[k]) {
+                hasValues = true;
                 curr[k] = branchInfo[i];
             }
 
@@ -120,6 +123,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         k = requestedPath[i];
         if (valueNode !== undefined) {
           if (k !== null) {
+              hasValues = true;
               curr[k] = valueNode;
           } else {
               // We are protected from reaching here when depth is 1 and prev is
@@ -128,4 +132,6 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
           }
         }
     }
+
+    outerResults.hasValues = hasValues;
 };

--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -62,10 +62,6 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         valueNode = nodeValue;
     }
 
-    if (outerResults) {
-        outerResults.hasValue = true;
-    }
-
     if (isJSONG) {
         curr = seed.jsonGraph;
         if (!curr) {

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -57,6 +57,9 @@ module.exports = function onValueType(
                     requestedPath, optimizedPath, optimizedLength,
                     isJSONG);
         } else {
+            onValue(model, undefined, seed, depth, outerResults, branchInfo,
+                    requestedPath, optimizedPath, optimizedLength,
+                    isJSONG);
             onError(model, node, depth, requestedPath, outerResults);
         }
     }

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -21,11 +21,14 @@ module.exports = function onValueType(
     // There are is nothing here, ether report value, or report the value
     // that is missing.  If there is no type then report the missing value.
     if (!node || !currType) {
-        if (isMaterialized(model)) {
+        var materialized = isMaterialized(model)
+        if (materialized || !isJSONG) {
             onValue(model, node, seed, depth, outerResults, branchInfo,
                     requestedPath, optimizedPath, optimizedLength,
                     isJSONG);
-        } else {
+        }
+
+        if (!materialized) {
             onMissing(model, path, depth,
                       outerResults, requestedPath,
                       optimizedPath, optimizedLength);

--- a/lib/get/onValueType.js
+++ b/lib/get/onValueType.js
@@ -21,7 +21,7 @@ module.exports = function onValueType(
     // There are is nothing here, ether report value, or report the value
     // that is missing.  If there is no type then report the missing value.
     if (!node || !currType) {
-        var materialized = isMaterialized(model)
+        var materialized = isMaterialized(model);
         if (materialized || !isJSONG) {
             onValue(model, node, seed, depth, outerResults, branchInfo,
                     requestedPath, optimizedPath, optimizedLength,

--- a/lib/get/util/clone.js
+++ b/lib/get/util/clone.js
@@ -2,6 +2,10 @@
 var privatePrefix = require("./../../internal/privatePrefix");
 
 module.exports = function clone(node) {
+    if (node === undefined) {
+        return node;
+    }
+
     var outValue, i, len;
     var keys = Object.keys(node);
     outValue = {};

--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -25,9 +25,8 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
         return;
     }
 
-    var keySet, i;
-    keySet = path[depth];
-
+    var i;
+    var keySet = path[depth];
     var isKeySet = typeof keySet === "object";
     var nextDepth = depth + 1;
     var iteratorNote = false;
@@ -37,12 +36,6 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
     if (isKeySet) {
         iteratorNote = {};
         key = iterateKeySet(keySet, iteratorNote);
-    }
-
-    // The key can be undefined if there is an empty path.  An example of an
-    // empty path is: [lolomo, [], summary].
-    if (key === undefined && iteratorNote.done) {
-        return;
     }
 
     // loop over every key over the keySet

--- a/lib/response/get/GetResponse.js
+++ b/lib/response/get/GetResponse.js
@@ -59,7 +59,7 @@ GetResponse.prototype._subscribe = function _subscribe(observer) {
     var isJSONG = observer.isJSONG = this.isJSONGraph;
     var isProgressive = this.isProgressive;
     var results = checkCacheAndReport(model, this.currentRemainingPaths,
-                                      observer, isProgressive, isJSONG, seed,
+                                      observer, isProgressive, isJSONG, {values: seed},
                                       errors);
 
     // If there are no results, finish.

--- a/lib/response/get/GetResponse.js
+++ b/lib/response/get/GetResponse.js
@@ -59,7 +59,7 @@ GetResponse.prototype._subscribe = function _subscribe(observer) {
     var isJSONG = observer.isJSONG = this.isJSONGraph;
     var isProgressive = this.isProgressive;
     var results = checkCacheAndReport(model, this.currentRemainingPaths,
-                                      observer, isProgressive, isJSONG, {values: seed},
+                                      observer, isProgressive, isJSONG, seed,
                                       errors);
 
     // If there are no results, finish.

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -47,7 +47,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     //
     // 2.  The request if finished and the json key off
     // the valueNode has a value.
-    if (progressive || ((progressive && results.hasValues || !progressive) && completed)) {
+    if (progressive || ((progressive && results.hasValues || !progressive) && completed && valueNode !== undefined)) {
         try {
             observer.onNext(valueNode);
         } catch (e) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -17,9 +17,10 @@ var getWithPathsAsPathMap = gets.getWithPathsAsPathMap;
  * @private
  */
 module.exports = function checkCacheAndReport(model, requestedPaths, observer,
-                                              progressive, isJSONG, seed,
+                                              progressive, isJSONG, prevResults,
                                               errors) {
 
+    var seed = prevResults.values;
     // checks the cache for the data.
     var results;
     if (isJSONG) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -54,7 +54,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     //
     // 2.  The request if finished and the json key off
     // the valueNode has a value.
-    if (progressive || completed) {
+    if (progressive || ((results.hasValues || (errors.length === 0 && !results.criticalError)) && completed)) {
         try {
             observer.onNext(valueNode);
         } catch (e) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -39,11 +39,10 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     // We are done when there are no missing paths or the model does not
     // have a dataSource to continue on fetching from.
     var valueNode = results.values[0];
-    var hasValues = results.hasValue;
+
     var completed = !results.requestedMissingPaths ||
                     !results.requestedMissingPaths.length ||
                     !model._source;
-    var hasValueOverall = Boolean(valueNode.json || valueNode.jsonGraph);
 
     // Copy the errors into the total errors array.
     if (results.errors) {
@@ -56,12 +55,11 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
 
     // If there are values to report, then report.
     // Which are under two conditions:
-    // 1.  This request for data yielded at least one value (hasValue) and  the
-    // request is progressive
+    // 1.  This request is progressive
     //
     // 2.  The request if finished and the json key off
     // the valueNode has a value.
-    if (hasValues && progressive || hasValueOverall && completed) {
+    if (progressive || completed) {
         try {
             observer.onNext(valueNode);
         } catch (e) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -28,6 +28,8 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
         results = getWithPathsAsPathMap(model, requestedPaths, seed);
     }
 
+    results.hasValues = results.hasValues || prevResults.hasValues;
+
     // We are done when there are no missing paths or the model does not
     // have a dataSource to continue on fetching from.
     var valueNode = results.values && results.values[0];

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -21,12 +21,21 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
                                               errors) {
 
     var seed = prevResults.values;
+    var prevVersion = prevResults.version;
+    var nextVersion = model._root.cache.$_version;
+    var versionChanged = nextVersion !== prevVersion || prevVersion === undefined;
+
     // checks the cache for the data.
     var results;
-    if (isJSONG) {
-        results = getWithPathsAsJSONGraph(model, requestedPaths, seed);
+    if (versionChanged) {
+        if (isJSONG) {
+            results = getWithPathsAsJSONGraph(model, requestedPaths, seed);
+        } else {
+            results = getWithPathsAsPathMap(model, requestedPaths, seed);
+        }
+        results.version = nextVersion;
     } else {
-        results = getWithPathsAsPathMap(model, requestedPaths, seed);
+        results = prevResults;
     }
 
     results.hasValues = results.hasValues || prevResults.hasValues;
@@ -54,7 +63,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     //
     // 2.  The request if finished and the json key off
     // the valueNode has a value.
-    if (progressive || ((results.hasValues || (errors.length === 0 && !results.criticalError)) && completed)) {
+    if (progressive || (((results.hasValues && versionChanged) || (errors.length === 0 && !results.criticalError)) && completed)) {
         try {
             observer.onNext(valueNode);
         } catch (e) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -47,7 +47,7 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
     //
     // 2.  The request if finished and the json key off
     // the valueNode has a value.
-    if (progressive || (((results.hasValues && versionChanged) || (errors.length === 0 && !results.criticalError)) && completed)) {
+    if (progressive || ((progressive && results.hasValues || !progressive) && completed)) {
         try {
             observer.onNext(valueNode);
         } catch (e) {

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -28,17 +28,9 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
         results = getWithPathsAsPathMap(model, requestedPaths, seed);
     }
 
-    // We must communicate critical errors from get that are critical
-    // errors such as bound path is broken or this is a JSONGraph request
-    // with a bound path.
-    if (results.criticalError) {
-        observer.onError(results.criticalError);
-        return null;
-    }
-
     // We are done when there are no missing paths or the model does not
     // have a dataSource to continue on fetching from.
-    var valueNode = results.values[0];
+    var valueNode = results.values && results.values[0];
 
     var completed = !results.requestedMissingPaths ||
                     !results.requestedMissingPaths.length ||
@@ -65,6 +57,14 @@ module.exports = function checkCacheAndReport(model, requestedPaths, observer,
         } catch (e) {
             throw e;
         }
+    }
+
+    // We must communicate critical errors from get that are critical
+    // errors such as bound path is broken or this is a JSONGraph request
+    // with a bound path.
+    if (results.criticalError) {
+        observer.onError(results.criticalError);
+        return null;
     }
 
     // if there are missing paths, then lets return them.

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -17,28 +17,12 @@ var getWithPathsAsPathMap = gets.getWithPathsAsPathMap;
  * @private
  */
 module.exports = function checkCacheAndReport(model, requestedPaths, observer,
-                                              progressive, isJSONG, prevResults,
+                                              progressive, isJSONG, seed,
                                               errors) {
 
-    var seed = prevResults.values;
-    var prevVersion = prevResults.version;
-    var nextVersion = model._root.cache.$_version;
-    var versionChanged = nextVersion !== prevVersion || prevVersion === undefined;
-
     // checks the cache for the data.
-    var results;
-    if (versionChanged) {
-        if (isJSONG) {
-            results = getWithPathsAsJSONGraph(model, requestedPaths, seed);
-        } else {
-            results = getWithPathsAsPathMap(model, requestedPaths, seed);
-        }
-        results.version = nextVersion;
-    } else {
-        results = prevResults;
-    }
-
-    results.hasValues = results.hasValues || prevResults.hasValues;
+    var results = isJSONG ? getWithPathsAsJSONGraph(model, requestedPaths, seed)
+                          : getWithPathsAsPathMap(model, requestedPaths, seed);
 
     // We are done when there are no missing paths or the model does not
     // have a dataSource to continue on fetching from.

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -54,6 +54,9 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
         get(boundRequestedMissingPaths, optimizedMissingPaths, function(err) {
 
             if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
+                if (results.hasValues) {
+                    observer.onNext(results.values && results.values[0]);
+                }
                 observer.onError(err);
                 return;
             }

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -64,7 +64,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
                                                   observer,
                                                   getResponse.isProgressive,
                                                   getResponse.isJSONGraph,
-                                                  results.values, errors);
+                                                  results, errors);
 
             // If there are missing paths coming back form checkCacheAndReport
             // the its reported from the core cache check method.

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -67,7 +67,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
                                                   observer,
                                                   getResponse.isProgressive,
                                                   getResponse.isJSONGraph,
-                                                  results, errors);
+                                                  results.values, errors);
 
             // If there are missing paths coming back form checkCacheAndReport
             // the its reported from the core cache check method.

--- a/lib/response/set/setRequestCycle.js
+++ b/lib/response/set/setRequestCycle.js
@@ -78,7 +78,8 @@ module.exports = function setRequestCycle(model, observer, groups,
                 var versionChanged = nextVersion !== prevVersion;
 
                 if (!versionChanged) {
-                    return observer.onCompleted();
+                    observer.onCompleted();
+                    return;
                 }
             }
 

--- a/lib/response/set/setRequestCycle.js
+++ b/lib/response/set/setRequestCycle.js
@@ -35,6 +35,7 @@ module.exports = function setRequestCycle(model, observer, groups,
 
 
     // Progressively output the data from the first set.
+    var prevVersion;
     if (isProgressive) {
         var results = getWithPathsAsPathMap(model, requestedPaths, [{}]);
         if (results.criticalError) {
@@ -42,6 +43,8 @@ module.exports = function setRequestCycle(model, observer, groups,
             return null;
         }
         observer.onNext(results.values[0]);
+
+        prevVersion = model._root.cache.$_version;
     }
 
     var currentJSONGraph = getJSONGraph(model, optimizedPaths);
@@ -67,6 +70,16 @@ module.exports = function setRequestCycle(model, observer, groups,
             var isCompleted = false;
             if (error || optimizedPaths.length === jsonGraphEnv.paths.length) {
                 isCompleted = true;
+            }
+
+            // If we're in progressive mode and nothing changed in the meantime, we're done
+            if (isProgressive) {
+                var nextVersion = model._root.cache.$_version;
+                var versionChanged = nextVersion !== prevVersion;
+
+                if (!versionChanged) {
+                    return observer.onCompleted();
+                }
             }
 
             // Happy case.  One request to the dataSource will fulfill the

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -23,6 +23,8 @@ module.exports = function mergeJSONGraphNode(
         cIsObject, mIsObject,
         cTimestamp, mTimestamp;
 
+    var nodeValue = node && node.value !== undefined ? node.value : node;
+
     // If the cache and message are the same, we can probably return early:
     // - If they're both nullsy,
     //   - If null then the node needs to be wrapped in an atom and inserted.
@@ -31,8 +33,7 @@ module.exports = function mergeJSONGraphNode(
     //   - If undefined then return null (previous behavior).
     // - If they're both branches, return the branch.
     // - If they're both edges, continue below.
-    if (node === message) {
-
+    if (nodeValue === message) {
         // There should not be undefined values.  Those should always be
         // wrapped in an $atom
         if (message === null) {
@@ -170,9 +171,10 @@ module.exports = function mergeJSONGraphNode(
                 //
                 // Comparing either Number or undefined to undefined always results in false.
                 isDistinct = (getTimestamp(message) < getTimestamp(node)) === false;
+
                 // If at least one of the cache/message are sentinels, compare them.
                 if (isDistinct && (cType || mType) && isFunction(comparator)) {
-                    isDistinct = !comparator(node, message, optimizedPath.slice(0, optimizedPath.index));
+                    isDistinct = !comparator(nodeValue, message, optimizedPath.slice(0, optimizedPath.index));
                 }
             }
             if (isDistinct) {

--- a/test/falcor/deref/deref.errors.spec.js
+++ b/test/falcor/deref/deref.errors.spec.js
@@ -7,6 +7,7 @@ var expect = require('chai').expect;
 var cacheGenerator = require('./../../CacheGenerator');
 var noOp = function() {};
 var isAssertionError = require('./../../isAssertionError');
+var clean = require("../../cleanData").clean;
 
 describe('Error cases', function() {
     it('should error on a shorted deref path.', function(done) {
@@ -33,6 +34,7 @@ describe('Error cases', function() {
                 toObservable(lolomoModel.
                     get([0, 0, 'item', 'title'])).
                     doAction(onNext, function(err) {
+                        expect(onNext.callCount).to.equal(1);
                         expect(err.message).to.equals(InvalidModelError.message);
                     }).
                     subscribe(

--- a/test/falcor/deref/deref.errors.spec.js
+++ b/test/falcor/deref/deref.errors.spec.js
@@ -36,7 +36,7 @@ describe('Error cases', function() {
                         expect(err.message).to.equals(InvalidModelError.message);
                     }).
                     subscribe(
-                        done.bind(null, new Error('onNext shouldnt be called')),
+                        noOp,
                         function(err) {
                             if (isAssertionError(err)) {
                                 return done(err);

--- a/test/falcor/error/index.js
+++ b/test/falcor/error/index.js
@@ -163,7 +163,7 @@ describe("Error", function() {
             subscribe(noOp, doneOnError(done), errorOnCompleted(done));
     });
 
-    it("should not onNext when only receiving errors.", function(done) {
+    it("should onNext when only receiving errors.", function(done) {
         var model = new Model({
             source: new Model({
                 cache: {
@@ -196,7 +196,15 @@ describe("Error", function() {
             doAction(onNext, function(err) {
 
                 // Ensure onNext is not called
-                expect(onNext.callCount, 'onNext called').to.equal(0);
+                expect(onNext.callCount, 'onNext called').to.equal(1);
+                expect(clean(onNext.getCall(0).args[0])).to.deep.equal({
+                    json: {
+                        test: {
+                            0: {},
+                            1: {}
+                        }
+                    }
+                });
 
                 // not in boxValue mode
                 var expected = [
@@ -244,7 +252,10 @@ describe("Error", function() {
                 expect(onNext.callCount, 'onNext called').to.equal(1);
                 expect(clean(onNext.getCall(0).args[0]), 'json from onNext').to.deep.equals({
                     json: {
-                        test: {}
+                        test: {
+                            0: {},
+                            5: {}
+                        }
                     }
                 });
 
@@ -304,7 +315,12 @@ describe("Error", function() {
         toObservable(model.
             get(['path', 'to', 'value'])).
             doAction(onNext, function(e) {
-                expect(onNext.callCount).to.equal(0);
+                expect(onNext.callCount).to.equal(1);
+                expect(clean(onNext.getCall(0).args[0])).to.deep.equal({
+                    json: {
+
+                    }
+                })
                 expect(e.name, 'Expect error to be an InvalidSourceError').to.equals(InvalidSourceError.name);
             }).
             subscribe(noOp, function(e) {

--- a/test/falcor/error/index.js
+++ b/test/falcor/error/index.js
@@ -17,9 +17,23 @@ describe("Error", function() {
             source: new ErrorDataSource(503, "Timeout"),
             _treatDataSourceErrorsAsJSONGraphErrors: true
         });
+        var onNext = sinon.spy();
         toObservable(model.
             get(["test", {to: 5}, "summary"])).
-            doAction(noOp, function(err) {
+            doAction(onNext, function(err) {
+                expect(onNext.callCount).to.equal(1);
+                expect(clean(onNext.getCall(0).args[0])).to.deep.equal({
+                    json: {
+                        test: {
+                            0: {},
+                            1: {},
+                            2: {},
+                            3: {},
+                            4: {},
+                            5: {}
+                        }
+                    }
+                });
                 expect(err.length).to.equal(6);
                 // not in boxValue mode
                 var expected = {
@@ -195,7 +209,6 @@ describe("Error", function() {
             get(["test", {to: 1}, "summary"])).
             doAction(onNext, function(err) {
 
-                // Ensure onNext is not called
                 expect(onNext.callCount, 'onNext called').to.equal(1);
                 expect(clean(onNext.getCall(0).args[0])).to.deep.equal({
                     json: {
@@ -248,7 +261,6 @@ describe("Error", function() {
             get(["test", {to: 5}, "summary"])).
             doAction(onNext, function(err) {
 
-                // Ensure onNext is not called
                 expect(onNext.callCount, 'onNext called').to.equal(1);
                 expect(clean(onNext.getCall(0).args[0]), 'json from onNext').to.deep.equals({
                     json: {

--- a/test/falcor/error/index.js
+++ b/test/falcor/error/index.js
@@ -33,9 +33,7 @@ describe("Error", function() {
                     expect(e).to.deep.equals(expected);
                 });
             }).
-            subscribe(function() {
-                done('Should not onNext');
-            },
+            subscribe(noOp,
             function(e) {
                 if (isAssertionError(e)) {
                     done(e);

--- a/test/falcor/get/get.cache-only.spec.js
+++ b/test/falcor/get/get.cache-only.spec.js
@@ -32,7 +32,7 @@ describe('Cache Only', function() {
                 }).
                 subscribe(noOp, done, done);
         });
-        it('should just complete on empty paths.', function(done) {
+        it('should onNext, then complete on empty paths.', function(done) {
             var model = new Model({
                 cache: cacheGenerator(0, 1)
             });
@@ -40,7 +40,12 @@ describe('Cache Only', function() {
             toObservable(model.
                 get(['videos', [], 'title'])).
                 doAction(onNext, noOp, function() {
-                    expect(onNext.callCount).to.equal(0);
+                    expect(clean(onNext.getCall(0).args[0])).to.deep.equals({
+                        json: {
+                            videos: {}
+                        }
+                    });
+                    expect(onNext.callCount).to.equal(1);
                 }).
                 subscribe(noOp, done, done);
         });

--- a/test/falcor/get/get.cacheAsDataSource.spec.js
+++ b/test/falcor/get/get.cacheAsDataSource.spec.js
@@ -11,6 +11,22 @@ var cacheGenerator = require('./../../CacheGenerator');
 var atom = Model.atom;
 
 describe('Cache as DataSource', function() {
+    it('should return the correct empty envelope.', function(done) {
+        var model = new Model({
+            cache: {foo: 1}
+        }).asDataSource();
+        var onNext = sinon.spy();
+        toObservable(model.
+            get([]).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(clean(onNext.getCall(0).args[0])).to.deep.equals({
+                    jsonGraph: {},
+                    paths: []
+                });
+            }).
+            subscribe(noOp, done, done));
+    });
     describe('toJSON', function() {
         it('should get a value from falcor.', function(done) {
             var model = new Model({

--- a/test/falcor/get/get.dataSource-and-cache.spec.js
+++ b/test/falcor/get/get.dataSource-and-cache.spec.js
@@ -589,6 +589,9 @@ describe('DataSource and Partial Cache', function() {
                     },
                     function() {
                         expect(onNextSpy.callCount).to.equal(1);
+                        expect(strip(onNextSpy.getCall(0).args[0])).to.deep.equals({
+                            json: {}
+                        });
                         expect(onErrorSpy.callCount).to.equal(1);
                         done();
                     });

--- a/test/falcor/get/get.dataSource-and-cache.spec.js
+++ b/test/falcor/get/get.dataSource-and-cache.spec.js
@@ -148,7 +148,10 @@ describe('DataSource and Partial Cache', function() {
             toObservable(modelGet).
                 doAction(onNext, noOp, function() {
                     expect(onGet.callCount).to.equals(0);
-                    expect(onNext.callCount).to.equals(0);
+                    expect(onNext.callCount).to.equals(1);
+                    expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                        json: {}
+                    });
                 }).
                 subscribe(noOp, done, done);
         });
@@ -171,7 +174,10 @@ describe('DataSource and Partial Cache', function() {
             toObservable(modelGet).
                 doAction(onNext, noOp, function() {
                     expect(onGet.callCount).to.equals(0);
-                    expect(onNext.callCount).to.equals(0);
+                    expect(onNext.callCount).to.equals(1);
+                    expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                        json: {}
+                    });
                 }).
                 subscribe(noOp, done, done);
         });
@@ -582,7 +588,7 @@ describe('DataSource and Partial Cache', function() {
                         done();
                     },
                     function() {
-                        expect(onNextSpy.callCount).to.equal(0);
+                        expect(onNextSpy.callCount).to.equal(1);
                         expect(onErrorSpy.callCount).to.equal(1);
                         done();
                     });

--- a/test/falcor/invalidate/invalidate.cache-only.spec.js
+++ b/test/falcor/invalidate/invalidate.cache-only.spec.js
@@ -45,7 +45,7 @@ describe("Cache Only", function() {
             subscribe(noOp, done, done);
     });
 
-    it.only("should re-fetch an invalidated value.", function(done) {
+    it("should re-fetch an invalidated value progressively.", function(done) {
         var onGet = sinon.spy();
         var onNext = sinon.spy();
         var model = new Model({
@@ -82,6 +82,47 @@ describe("Cache Only", function() {
                     }
                 });
                 expect(strip(onNext.getCall(2).args[0])).to.deep.equals({
+                    json: {
+                        lolomo: {
+                            0: {
+                                title: 'List title'
+                            }
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+
+        model.invalidate(['lolomo', 0]);
+    });
+
+    it("should re-fetch an invalidated value.", function(done) {
+        var onGet = sinon.spy();
+        var onNext = sinon.spy();
+        var model = new Model({
+            cache: {
+                lolomo: {
+                    0: ref(['lists', 123])
+                }
+            },
+            source: new LocalDataSource({
+                    lolomo: {
+                        0: ref(['lists', 123])
+                    },
+                    lists: {
+                        123: {
+                            title: atom('List title')
+                        }
+                    }
+                }, {wait: 100, onGet: onGet})
+        });
+
+        toObservable(model.
+            get(["lolomo", 0, "title"])).
+            doAction(onNext, noOp, function() {
+                expect(onGet.callCount).to.equal(2);
+                expect(onNext.callCount).to.equal(1);
+                expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
                     json: {
                         lolomo: {
                             0: {

--- a/test/falcor/invalidate/invalidate.cache-only.spec.js
+++ b/test/falcor/invalidate/invalidate.cache-only.spec.js
@@ -15,10 +15,6 @@ var atom = jsonGraph.atom;
 
 describe("Cache Only", function() {
     it("should invalidate a leaf value.", function(done) {
-        var dataSourceCount = sinon.spy();
-        var dataSource = new LocalDataSource({}, {
-            onGet: dataSourceCount
-        });
         var model = new Model({
             cache: cacheGenerator(0, 1, ['title', 'art'])
         });
@@ -27,11 +23,9 @@ describe("Cache Only", function() {
             invalidate(["videos", 0, "title"]);
 
         toObservable(model.
-            withoutDataSource().
             get(["videos", 0, "title"])).
             concat(model.get(["videos", 0, "art"])).
             doAction(onNext, noOp, function() {
-                expect(dataSourceCount.callCount).to.equals(0);
                 expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         videos: {
@@ -160,6 +154,9 @@ describe("Cache Only", function() {
             doAction(onNext, noOp, function() {
                 expect(onGet.calledOnce).to.be.ok;
                 expect(onGet.getCall(0).args[1]).to.deep.equals([art]);
+                expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                    json: {}
+                });
                 expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         videos: {
@@ -187,6 +184,9 @@ describe("Cache Only", function() {
             get(summary.slice())).
             concat(model.get(["lists", "A", 0, "item", "summary"])).
             doAction(onNext, noOp, function() {
+                 expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                    json: {}
+                });
                 expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         lists: {

--- a/test/falcor/invalidate/invalidate.cache-only.spec.js
+++ b/test/falcor/invalidate/invalidate.cache-only.spec.js
@@ -26,13 +26,10 @@ describe("Cache Only", function() {
         toObservable(model.
             withoutDataSource().
             get(["videos", 0, "title"])).
-            doAction(function(x) {
-                throw inspect(x, {depth: 10}) + " should not be onNext'd";
-            }).
             concat(model.get(["videos", 0, "art"])).
             doAction(onNext, noOp, function() {
                 expect(dataSourceCount.callCount).to.equals(0);
-                expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         videos: {
                             0: {
@@ -64,14 +61,11 @@ describe("Cache Only", function() {
         toObservable(model.
             withoutDataSource().
             get(summary.slice())).
-            doAction(function(x) {
-                throw inspect(x, {depth: 10}) + " should not be onNext'd";
-            }).
             concat(model.get(art.slice())).
             doAction(onNext, noOp, function() {
                 expect(onGet.calledOnce).to.be.ok;
                 expect(onGet.getCall(0).args[1]).to.deep.equals([art]);
-                expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         videos: {
                             0: {
@@ -96,12 +90,9 @@ describe("Cache Only", function() {
         toObservable(model.
             withoutDataSource().
             get(summary.slice())).
-            doAction(function(x) {
-                throw inspect(x, {depth: 10}) + " should not be onNext'd";
-            }).
             concat(model.get(["lists", "A", 0, "item", "summary"])).
             doAction(onNext, noOp, function() {
-                expect(strip(onNext.getCall(0).args[0])).to.deep.equals({
+                expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
                     json: {
                         lists: {
                             A: {

--- a/test/falcor/set/set.cacheAsDataSource-and-cache.spec.js
+++ b/test/falcor/set/set.cacheAsDataSource-and-cache.spec.js
@@ -135,9 +135,7 @@ describe('Cache as DataSource and Cache', function() {
         toObservable(model.
             boxValues().
             set({path: ['genreList', 0, 0, 'summary'], value: 5})).
-            doAction(function(x) {
-                expect(false, 'onNext should not be called.').to.be.ok;
-            }, function(e) {
+            doAction(noOp, function(e) {
                 called = true;
                 testRunner.compare([{
                     path: ['genreList', 0, 0, 'summary'],

--- a/test/falcor/set/set.cacheAsDataSource-and-cache.spec.js
+++ b/test/falcor/set/set.cacheAsDataSource-and-cache.spec.js
@@ -149,7 +149,7 @@ describe('Cache as DataSource and Cache', function() {
                     }
                 }], e, {strip: ['$size']});
             }, function() {
-                expect(false, 'onNext should not be called.').to.be.ok;
+                expect(false, 'onCompleted should not be called.').to.be.ok;
             }).
             subscribe(noOp, function(e) {
                 if (Array.isArray(e) && e[0].value.$foo === 'bar' && called) {

--- a/test/falcor/set/set.dataSource-and-cache.spec.js
+++ b/test/falcor/set/set.dataSource-and-cache.spec.js
@@ -205,9 +205,7 @@ describe('DataSource and Cache', function() {
         toObservable(model.
             boxValues().
             set({path: ['genreList', 0, 0, 'summary'], value: 5})).
-            doAction(function(x) {
-                expect(false, 'onNext should not be called.').to.be.ok;
-            }, function(e) {
+            doAction(noOp, function(e) {
                 called = true;
                 testRunner.compare([{
                     path: ['genreList', 0, 0, 'summary'],

--- a/test/falcor/set/set.dataSource-and-cache.spec.js
+++ b/test/falcor/set/set.dataSource-and-cache.spec.js
@@ -186,7 +186,7 @@ describe('DataSource and Cache', function() {
                 subscribe(noOp, done, done);
         });
 
-        it.only('should onNext twice in progressive mode if the server response is not identical.', function(done) {
+        it('should onNext twice in progressive mode if the server response is not identical.', function(done) {
             var count = 0;
             var model = new Model({
                 source: new LocalDataSource(Cache(), {

--- a/test/falcor/set/set.dataSource-and-cache.spec.js
+++ b/test/falcor/set/set.dataSource-and-cache.spec.js
@@ -192,7 +192,7 @@ describe('DataSource and Cache', function() {
                 source: new LocalDataSource(Cache(), {
                     onSet: function(self, model, jsongEnv) {
                         var copy = JSON.parse(JSON.stringify(jsongEnv));
-                        copy.json.genreList[0][0].summary = 7331;
+                        copy.jsonGraph.genreList[0][0].summary = 7331;
                         return copy;
                     }
                 })
@@ -209,6 +209,17 @@ describe('DataSource and Cache', function() {
                                 0: {
                                     0: {
                                         summary: 1337
+                                    }
+                                }
+                            }
+                        }
+                    });
+                    expect(strip(onNext.getCall(1).args[0])).to.deep.equals({
+                        json: {
+                            genreList: {
+                                0: {
+                                    0: {
+                                        summary: 7331
                                     }
                                 }
                             }

--- a/test/falcor/set/set.setCache.spec.js
+++ b/test/falcor/set/set.setCache.spec.js
@@ -25,7 +25,6 @@ describe('Set Cache', function() {
             a: { b: $ref("a"),
                  c: "foo" }
         })});
-        debugger
         model.setCache(undefined);
         model.get("a.b.c").subscribe(function(x) {
             expect(clean(x)).to.deep.equal({

--- a/test/get-core/deref.spec.js
+++ b/test/get-core/deref.spec.js
@@ -54,7 +54,11 @@ describe('Deref', function() {
                 ['b', 'c'],
                 ['b', 'd']
             ],
-            output: { },
+            output: {
+                json: {
+                    b: {}
+                }
+            },
             deref: ['a'],
             optimizedMissingPaths: [
                 ['a', 'b', 'c'],

--- a/test/get-core/edges.spec.js
+++ b/test/get-core/edges.spec.js
@@ -14,7 +14,11 @@ describe('Edges', function() {
     it('should report nothing on empty path.', function() {
         getCoreRunner({
             input: [['videos', [], 'title']],
-            output: { },
+            output: {
+                json: {
+                    videos: {}
+                }
+            },
             cache: cacheGenerator(0, 1)
         });
     });

--- a/test/get-core/edges.spec.js
+++ b/test/get-core/edges.spec.js
@@ -104,7 +104,11 @@ describe('Edges', function() {
     it('should not get out an expired item through references.', function() {
         getCoreRunner({
             input: [['videos', 1234, 'title']],
-            output: { },
+            output: {
+                json: {
+                    videos: {}
+                }
+            },
             requestedMissingPaths: [['videos', 1234, 'title']],
             cache: {
                 to: {

--- a/test/get-core/errors.spec.js
+++ b/test/get-core/errors.spec.js
@@ -48,7 +48,11 @@ describe('Errors', function() {
     it('should report error with path.', function() {
         getCoreRunner({
             input: [['to', 'error']],
-            output: { },
+            output: {
+                json: {
+                    to: {}
+                }
+            },
             errors: [{
                 path: ['to', 'error'],
                 value: 'Oops!'
@@ -64,7 +68,8 @@ describe('Errors', function() {
             ],
             output: {
                 json: {
-                    foo: fooBranch()
+                    foo: fooBranch(),
+                    to: {}
                 }
             },
             errors: [{
@@ -77,7 +82,11 @@ describe('Errors', function() {
     it('should report error path with null from reference.', function() {
         getCoreRunner({
             input: [['reference', 'title']],
-            output: { },
+            output: {
+                json: {
+                    reference: {}
+                }
+            },
             errors: [{
                 path: ['reference', null],
                 value: 'Oops!'
@@ -88,7 +97,11 @@ describe('Errors', function() {
     it('should report error path with null from reference with path ending in null.', function() {
         getCoreRunner({
             input: [['reference', null]],
-            output: { },
+            output: {
+                json: {
+                    reference: {}
+                }
+            },
             errors: [{
                 path: ['reference', null],
                 value: 'Oops!'
@@ -189,7 +202,8 @@ describe('Errors', function() {
         var list = {
             0: {
                 title: 'Hello World'
-            }
+            },
+            1: {}
         };
         list.$__path = ['list'];
         list[0].$__path = ['to'];

--- a/test/get-core/missing.spec.js
+++ b/test/get-core/missing.spec.js
@@ -21,7 +21,9 @@ describe('Missing', function() {
     it('should report a missing path.', function() {
         getCoreRunner({
             input: [['missing', 'title']],
-            output: { },
+            output: {
+                json: {}
+            },
             requestedMissingPaths: [['missing', 'title']],
             optimizedMissingPaths: [['toMissing', 'title']],
             cache: missingCache
@@ -30,7 +32,13 @@ describe('Missing', function() {
     it('should report a missing path.', function() {
         getCoreRunner({
             input: [['multi', {to: 1}, 0, 'title']],
-            output: { },
+            output: {
+                json: {
+                    multi: {
+                        1: {}
+                    }
+                }
+            },
             requestedMissingPaths: [
                 ['multi', 0, 0, 'title'],
                 ['multi', 1, 0, 'title']
@@ -57,7 +65,18 @@ describe('Missing', function() {
     it('should report missing paths through many complex keys.', function() {
         getCoreRunner({
             input: [[{to:1}, {to:1}, {to:1}, 'summary']],
-            output: { },
+            output: {
+                json: {
+                    0: {
+                        0: {
+                            0: {},
+                            1: {}
+                        },
+                        1: {}
+                    },
+                    1: {}
+                }
+            },
             optimizedMissingPaths: [
                 [0, 0, 0, 'summary'],
                 [0, 0, 1, 'summary'],
@@ -97,7 +116,9 @@ describe('Missing', function() {
     it('should report a missing path ending with null', function() {
         getCoreRunner({
             input: [['refMissing', null]],
-            output: { },
+            output: {
+                json: {}
+            },
             requestedMissingPaths: [['refMissing', null]],
             optimizedMissingPaths: [['refMissing', null]],
             cache: { }

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -152,34 +152,41 @@ describe('Values', function() {
             }
         });
     });
-    it('should not clobber values with intersecting paths.', function() {
-        getCoreRunner({
-            input: [['lists', 2343, '0', 'name'], ['lists', 2343, '0']],
-            output: {
-                json: {
-                    lists: {
-                        2343: {
-                            0: {
-                                name: 'House of cards'
+
+    function intersectingTest(paths) {
+        return function() {
+            getCoreRunner({
+                input: paths,
+                output: {
+                    json: {
+                        lists: {
+                            2343: {
+                                0: {
+                                    name: 'House of cards'
+                                }
                             }
                         }
                     }
-                }
-            },
-            cache: {
-                lists: {
-                    2343: {
-                        0: jsonGraph.ref(["videos", 123])
-                    }
                 },
-                videos: {
-                    123: {
-                        name: atom("House of cards")
+                cache: {
+                    lists: {
+                        2343: {
+                            0: jsonGraph.ref(["videos", 123])
+                        }
+                    },
+                    videos: {
+                        123: {
+                            name: atom("House of cards")
+                        }
                     }
                 }
-            }
-        });
-    });
+            });
+        };
+    }
+
+    it('should not clobber values with intersecting paths.', intersectingTest([['lists', 2343, '0', 'name'], ['lists', 2343, '0']]));
+    it('should not clobber values with intersecting paths reversed.', intersectingTest([['lists', 2343, '0'], ['lists', 2343, '0', 'name']]));
+
     it('should have identical behavior when fetching a missing value or atom of undefined.', function() {
         getCoreRunner({
             input: [["lists", 2343, "0", "name"], ["lists", 2343, "1", "rating"]],
@@ -208,6 +215,7 @@ describe('Values', function() {
             }
         });
     });
+
     it('should have no output for empty paths.', function() {
         getCoreRunner({
             input: [['lolomo', 0, [], 'item', 'title']],

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -180,6 +180,34 @@ describe('Values', function() {
             }
         });
     });
+    it('should have identical behavior when fetching a missing value or atom of undefined.', function() {
+        getCoreRunner({
+            input: [["lists", 2343, "0", "name"], ["lists", 2343, "1", "rating"]],
+            output: {
+                json: {
+                    lists: {
+                        2343: {
+                            0: {},
+                            1: {}
+                        }
+                    }
+                }
+            },
+            cache: {
+                lists: {
+                    2343: {
+                        0: jsonGraph.ref(["videos", 123]),
+                        1: jsonGraph.ref(["videos", 123])
+                    }
+                },
+                videos: {
+                    123: {
+                        name: atom()
+                    }
+                }
+            }
+        });
+    });
     it('should have no output for empty paths.', function() {
         getCoreRunner({
             input: [['lolomo', 0, [], 'item', 'title']],

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -216,14 +216,14 @@ describe('Values', function() {
         });
     });
 
-    it('should have no output for empty paths.', function() {
+    it('should emit branch structure for empty paths.', function() {
         getCoreRunner({
             input: [['lolomo', 0, [], 'item', 'title']],
             output: {
                 json: {
                     lolomo: {
                         0: {
-                            
+
                         }
                     }
                 }
@@ -232,7 +232,7 @@ describe('Values', function() {
         });
     });
 
-    it('should have no output for empty get.', function() {
+    it('should emit branch structure for empty get.', function() {
         getCoreRunner({
             input: [],
             output: {

--- a/test/get-core/values.spec.js
+++ b/test/get-core/values.spec.js
@@ -219,7 +219,25 @@ describe('Values', function() {
     it('should have no output for empty paths.', function() {
         getCoreRunner({
             input: [['lolomo', 0, [], 'item', 'title']],
-            output: {},
+            output: {
+                json: {
+                    lolomo: {
+                        0: {
+                            
+                        }
+                    }
+                }
+            },
+            cache: cacheGenerator(0, 1)
+        });
+    });
+
+    it('should have no output for empty get.', function() {
+        getCoreRunner({
+            input: [],
+            output: {
+                json: {}
+            },
             cache: cacheGenerator(0, 1)
         });
     });

--- a/test/getCoreRunner.js
+++ b/test/getCoreRunner.js
@@ -19,7 +19,7 @@ module.exports = function(testConfig) {
     var optimizedMissingPaths = testConfig.optimizedMissingPaths;
     var errors = testConfig.errors;
     var type = testConfig.input && testConfig.input[0] ||
-        testConfig.inputs[0][0];
+        testConfig.inputs && testConfig.inputs[0] && testConfig.inputs[0][0];
     var isJSONInput = !Array.isArray(type);
     var fnKey = 'getWithPathsAs' + (isJSONG ? 'JSONGraph' : 'PathMap');
     var fn = get[fnKey];

--- a/test/integration/call.spec.js
+++ b/test/integration/call.spec.js
@@ -114,6 +114,11 @@ describe('call', function() {
             doAction(onNext, noOp, noOp).
             subscribe(noOp, done, function() {
                 expect(onNext.callCount).to.equal(1);
+                expect(strip(onNext.getCall(0).args[0])).to.deep.equal({
+                    json: {
+
+                    }
+                });
                 done();
             });
     });

--- a/test/integration/call.spec.js
+++ b/test/integration/call.spec.js
@@ -113,7 +113,7 @@ describe('call', function() {
             call("genreList[0].titles.push", args)).
             doAction(onNext, noOp, noOp).
             subscribe(noOp, done, function() {
-                expect(onNext.callCount).to.equal(0);
+                expect(onNext.callCount).to.equal(1);
                 done();
             });
     });

--- a/test/internal/request/RequestQueue.get.spec.js
+++ b/test/internal/request/RequestQueue.get.spec.js
@@ -221,7 +221,7 @@ describe('#get', function() {
                 get(videos0, videos1)).
                 doAction(onNext, noOp, function() {
                     expect(zip.callCount).to.equal(0);
-                    expect(onNext.callCount).to.equal(0);
+                    expect(onNext.callCount).to.equal(1);
                 }).
                 subscribe(noOp, done, done);
         }, 300);
@@ -291,7 +291,7 @@ describe('#get', function() {
                 get(videos0, videos1)).
                 doAction(onNext, noOp, function() {
                     expect(zip.callCount).to.equal(0);
-                    expect(onNext.callCount).to.equal(0);
+                    expect(onNext.callCount).to.equal(1);
                 }).
                 subscribe(noOp, done, done);
         }, 300);

--- a/test/lru/lru.splice.expired.spec.js
+++ b/test/lru/lru.splice.expired.spec.js
@@ -34,8 +34,7 @@ describe('Expired', function() {
                 return model.get(['expireSoon', 'summary']);
             }).
             doAction(onNext, noOp, function() {
-                debugger
-                expect(onNext.callCount).to.equal(0);
+                expect(onNext.callCount).to.equal(1);
                 expect(model._root[__head]).to.be.not.ok;
                 expect(model._root[__tail]).to.be.not.ok;
             }).


### PR DESCRIPTION
Currently, a get() for paths that are missing in the cache behaves differently than a get() for atoms of undefined. This PR makes both conditions produce identical results, and ensures onNext() is always called on the model result.