### PR TITLE
Fix merging references over branches

### DIFF
--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -18,7 +18,7 @@ function mergeInto(target, obj) {
         // When merging over a temporary branch structure (for example, as produced by an error selector)
         // with references, we don't want to mutate the path, particularly because it's also $_absolutePath
         // on cache nodes
-        if (key === '$__path') {
+        if (key === "$__path") {
             continue;
         }
 

--- a/lib/get/get.js
+++ b/lib/get/get.js
@@ -13,7 +13,15 @@ function mergeInto(target, obj) {
     if (obj === null || typeof obj !== "object" || obj.$type) {
         return;
     }
+
     for (var key in obj) {
+        // When merging over a temporary branch structure (for example, as produced by an error selector)
+        // with references, we don't want to mutate the path, particularly because it's also $_absolutePath
+        // on cache nodes
+        if (key === '$__path') {
+            continue;
+        }
+
         var targetValue = target[key];
         if (targetValue === undefined) {
             target[key] = obj[key];

--- a/lib/invalidate/invalidatePathSets.js
+++ b/lib/invalidate/invalidatePathSets.js
@@ -82,7 +82,7 @@ function invalidatePathSet(
                     root, nextParent, nextNode,
                     version, expired, lru
                 );
-            } else if (removeNodeAndDescendants(nextNode, nextParent, key, lru)) {
+            } else if (removeNodeAndDescendants(nextNode, nextParent, key, lru, undefined)) {
                 updateNodeAncestors(nextParent, getSize(nextNode), lru, version);
             }
         }

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -84,15 +84,15 @@ GetRequestV2.prototype = {
                         // If there is at least one callback remaining, then
                         // callback the callbacks.
                         if (self._count) {
-                            self._merge(rPaths, err, data);
-
+                            var replacedPaths = [];
+                            self._merge(rPaths, err, data, replacedPaths);
                             // Call the callbacks.  The first one inserts all
                             // the data so that the rest do not have consider
                             // if their data is present or not.
                             for (i = 0, len = callbacks.length; i < len; ++i) {
                                 fn = callbacks[i];
                                 if (fn) {
-                                    fn(err, data);
+                                    fn(err, data, replacedPaths);
                                 }
                             }
                         }
@@ -157,7 +157,7 @@ GetRequestV2.prototype = {
     /**
      * merges the response into the model"s cache.
      */
-    _merge: function(requested, err, data) {
+    _merge: function(requested, err, data, replacedPaths) {
         var self = this;
         var model = self.requestQueue.model;
         var modelRoot = model._root;
@@ -196,7 +196,7 @@ GetRequestV2.prototype = {
                     value: error
                 };
             });
-            setPathValues(model, pathValues, null, errorSelector, comparator);
+            setPathValues(model, pathValues, null, errorSelector, comparator, replacedPaths);
         }
 
         // Insert the jsonGraph from the dataSource.
@@ -204,7 +204,7 @@ GetRequestV2.prototype = {
             setJSONGraphs(model, [{
                 paths: nextPaths,
                 jsonGraph: data.jsonGraph
-            }], null, errorSelector, comparator);
+            }], null, errorSelector, comparator, replacedPaths);
         }
 
         // return the model"s boundPath

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -84,15 +84,15 @@ GetRequestV2.prototype = {
                         // If there is at least one callback remaining, then
                         // callback the callbacks.
                         if (self._count) {
-                            var replacedPaths = [];
-                            self._merge(rPaths, err, data, replacedPaths);
+                            var mergeContext = {hasInvalidatedResult : false};
+                            self._merge(rPaths, err, data, mergeContext);
                             // Call the callbacks.  The first one inserts all
                             // the data so that the rest do not have consider
                             // if their data is present or not.
                             for (i = 0, len = callbacks.length; i < len; ++i) {
                                 fn = callbacks[i];
                                 if (fn) {
-                                    fn(err, data, replacedPaths);
+                                    fn(err, data, mergeContext.hasInvalidatedResult);
                                 }
                             }
                         }
@@ -157,7 +157,7 @@ GetRequestV2.prototype = {
     /**
      * merges the response into the model"s cache.
      */
-    _merge: function(requested, err, data, replacedPaths) {
+    _merge: function(requested, err, data, mergeContext) {
         var self = this;
         var model = self.requestQueue.model;
         var modelRoot = model._root;
@@ -196,7 +196,7 @@ GetRequestV2.prototype = {
                     value: error
                 };
             });
-            setPathValues(model, pathValues, null, errorSelector, comparator, replacedPaths);
+            setPathValues(model, pathValues, null, errorSelector, comparator, mergeContext);
         }
 
         // Insert the jsonGraph from the dataSource.
@@ -204,7 +204,7 @@ GetRequestV2.prototype = {
             setJSONGraphs(model, [{
                 paths: nextPaths,
                 jsonGraph: data.jsonGraph
-            }], null, errorSelector, comparator, replacedPaths);
+            }], null, errorSelector, comparator, mergeContext);
         }
 
         // return the model"s boundPath

--- a/lib/request/RequestQueueV2.js
+++ b/lib/request/RequestQueueV2.js
@@ -104,7 +104,7 @@ RequestQueueV2.prototype = {
         }
 
         // This is a simple refCount callback.
-        function refCountCallback(err) {
+        function refCountCallback(err, data, replacedPaths) {
             if (disposed) {
                 return;
             }
@@ -114,7 +114,7 @@ RequestQueueV2.prototype = {
             // If the count becomes 0, then its time to notify the
             // listener that the request is done.
             if (count === 0) {
-                cb(err);
+                cb(err, data, replacedPaths);
             }
         }
 

--- a/lib/request/RequestQueueV2.js
+++ b/lib/request/RequestQueueV2.js
@@ -104,7 +104,7 @@ RequestQueueV2.prototype = {
         }
 
         // This is a simple refCount callback.
-        function refCountCallback(err, data, replacedPaths) {
+        function refCountCallback(err, data, hasInvalidatedResult) {
             if (disposed) {
                 return;
             }
@@ -114,7 +114,7 @@ RequestQueueV2.prototype = {
             // If the count becomes 0, then its time to notify the
             // listener that the request is done.
             if (count === 0) {
-                cb(err, data, replacedPaths);
+                cb(err, data, hasInvalidatedResult);
             }
         }
 

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -51,14 +51,17 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
     }
 
     var currentRequestDisposable = requestQueue.
-        get(boundRequestedMissingPaths, optimizedMissingPaths, function(err) {
-
+        get(boundRequestedMissingPaths, optimizedMissingPaths, function(err, data, replacedPaths) {
             if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
                 if (results.hasValues) {
                     observer.onNext(results.values && results.values[0]);
                 }
                 observer.onError(err);
                 return;
+            }
+
+            if (replacedPaths.length) {
+                requestedMissingPaths.push.apply(requestedMissingPaths, replacedPaths);
             }
 
             // Once the request queue finishes, check the cache and bail if

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -51,7 +51,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
     }
 
     var currentRequestDisposable = requestQueue.
-        get(boundRequestedMissingPaths, optimizedMissingPaths, function(err, data, replacedPaths) {
+        get(boundRequestedMissingPaths, optimizedMissingPaths, function(err, data, hasInvalidatedResult) {
             if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
                 if (results.hasValues) {
                     observer.onNext(results.values && results.values[0]);
@@ -60,17 +60,26 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
                 return;
             }
 
-            if (replacedPaths.length) {
-                requestedMissingPaths.push.apply(requestedMissingPaths, replacedPaths);
+            var nextRequestedMissingPaths;
+            var nextSeed;
+
+            // If merging over an existing branch structure with refs has invalidated our intermediate json,
+            // we want to start over and re-get all requested paths with a fresh seed
+            if (hasInvalidatedResult) {
+                nextRequestedMissingPaths = getResponse.currentRemainingPaths;
+                nextSeed = [{}];
+            } else {
+                nextRequestedMissingPaths = requestedMissingPaths;
+                nextSeed = results.values;
             }
 
-            // Once the request queue finishes, check the cache and bail if
-            // we can.
-            var nextResults = checkCacheAndReport(model, requestedMissingPaths,
+             // Once the request queue finishes, check the cache and bail if
+             // we can.
+            var nextResults = checkCacheAndReport(model, nextRequestedMissingPaths,
                                                   observer,
                                                   getResponse.isProgressive,
                                                   getResponse.isJSONGraph,
-                                                  results.values, errors);
+                                                  nextSeed, errors);
 
             // If there are missing paths coming back form checkCacheAndReport
             // the its reported from the core cache check method.

--- a/lib/set/setJSONGraphs.js
+++ b/lib/set/setJSONGraphs.js
@@ -18,7 +18,7 @@ var NullInPathError = require("./../errors/NullInPathError");
  * @return {Array.<Array.<Path>>} - an Array of Arrays where each inner Array is a list of requested and optimized paths (respectively) for the successfully set values.
  */
 
-module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelector, comparator) {
+module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelector, comparator, replacedPaths) {
 
     var modelRoot = model._root;
     var lru = modelRoot;
@@ -53,7 +53,7 @@ module.exports = function setJSONGraphs(model, jsonGraphEnvelopes, x, errorSelec
                 cache, cache, cache,
                 jsonGraph, jsonGraph, jsonGraph,
                 requestedPaths, optimizedPaths, requestedPath, optimizedPath,
-                version, expired, lru, comparator, errorSelector
+                version, expired, lru, comparator, errorSelector, replacedPaths
             );
         }
     }
@@ -73,7 +73,7 @@ function setJSONGraphPathSet(
     path, depth, root, parent, node,
     messageRoot, messageParent, message,
     requestedPaths, optimizedPaths, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var note = {};
     var branch = depth < path.length - 1;
@@ -88,7 +88,7 @@ function setJSONGraphPathSet(
         var results = setNode(
             root, parent, node, messageRoot, messageParent, message,
             key, branch, false, requestedPath, optimizedPath,
-            version, expired, lru, comparator, errorSelector
+            version, expired, lru, comparator, errorSelector, replacedPaths
         );
 
         requestedPath[depth] = key;
@@ -102,7 +102,7 @@ function setJSONGraphPathSet(
                     path, depth + 1, root, nextParent, nextNode,
                     messageRoot, results[3], results[2],
                     requestedPaths, optimizedPaths, requestedPath, optimizedPath,
-                    version, expired, lru, comparator, errorSelector
+                    version, expired, lru, comparator, errorSelector, replacedPaths
                 );
             } else {
                 requestedPaths.push(requestedPath.slice(0, requestedPath.index + 1));
@@ -120,7 +120,7 @@ function setJSONGraphPathSet(
 
 function setReference(
     root, node, messageRoot, message, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var reference = node.value;
     optimizedPath.splice(0, optimizedPath.length);
@@ -146,7 +146,7 @@ function setReference(
         var results = setNode(
             root, parent, node, messageRoot, messageParent, message,
             key, branch, true, requestedPath, optimizedPath,
-            version, expired, lru, comparator, errorSelector
+            version, expired, lru, comparator, errorSelector, replacedPaths
         );
         node = results[0];
         if (isPrimitive(node)) {
@@ -170,7 +170,7 @@ function setReference(
 function setNode(
     root, parent, node, messageRoot, messageParent, message,
     key, branch, reference, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var type = node.$type;
 
@@ -178,7 +178,7 @@ function setNode(
 
         var results = setReference(
             root, node, messageRoot, message, requestedPath, optimizedPath,
-            version, expired, lru, comparator, errorSelector
+            version, expired, lru, comparator, errorSelector, replacedPaths
         );
 
         node = results[0];
@@ -212,7 +212,7 @@ function setNode(
 
     node = mergeJSONGraphNode(
         parent, node, message, key, requestedPath, optimizedPath,
-        version, expired, lru, comparator, errorSelector
+        version, expired, lru, comparator, errorSelector, replacedPaths
     );
 
     return [node, parent, message, messageParent];

--- a/lib/set/setPathValues.js
+++ b/lib/set/setPathValues.js
@@ -68,7 +68,7 @@ module.exports = function setPathValues(model, pathValues, x, errorSelector, com
 function setPathSet(
     value, path, depth, root, parent, node,
     requestedPaths, optimizedPaths, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var note = {};
     var branch = depth < path.length - 1;
@@ -83,7 +83,7 @@ function setPathSet(
         var results = setNode(
             root, parent, node, key, value,
             branch, false, requestedPath, optimizedPath,
-            version, expired, lru, comparator, errorSelector
+            version, expired, lru, comparator, errorSelector, replacedPaths
         );
         requestedPath[depth] = key;
         requestedPath.index = depth;
@@ -114,7 +114,7 @@ function setPathSet(
 
 function setReference(
     value, root, node, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var reference = node.value;
     optimizedPath.splice(0, optimizedPath.length);
@@ -149,7 +149,7 @@ function setReference(
             var results = setNode(
                 root, parent, node, key, value,
                 branch, true, requestedPath, optimizedPath,
-                version, expired, lru, comparator, errorSelector
+                version, expired, lru, comparator, errorSelector, replacedPaths
             );
             node = results[0];
             if (isPrimitive(node)) {
@@ -172,7 +172,7 @@ function setReference(
 function setNode(
     root, parent, node, key, value,
     branch, reference, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var type = node.$type;
 
@@ -180,7 +180,7 @@ function setNode(
 
         var results = setReference(
             value, root, node, requestedPath, optimizedPath,
-            version, expired, lru, comparator, errorSelector
+            version, expired, lru, comparator, errorSelector, replacedPaths
         );
 
         node = results[0];
@@ -211,7 +211,7 @@ function setNode(
     node = mergeValueOrInsertBranch(
         parent, node, key, value,
         branch, reference, requestedPath, optimizedPath,
-        version, expired, lru, comparator, errorSelector
+        version, expired, lru, comparator, errorSelector, replacedPaths
     );
 
     return [node, parent];

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -15,7 +15,7 @@ var reconstructPath = require("./../support/reconstructPath");
 
 module.exports = function mergeJSONGraphNode(
     parent, node, message, key, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var sizeOffset;
 
@@ -134,7 +134,7 @@ module.exports = function mergeJSONGraphNode(
 
     // If the cache is a leaf but the message is a branch, merge the branch over the leaf.
     if (cType && mIsObject && !mType) {
-        return insertNode(replaceNode(node, message, parent, key, lru), parent, key, undefined, optimizedPath);
+        return insertNode(replaceNode(node, message, parent, key, lru, replacedPaths), parent, key, undefined, optimizedPath);
     }
     // If the message is a sentinel or primitive, insert it into the cache.
     else if (mType || !mIsObject) {
@@ -180,7 +180,7 @@ module.exports = function mergeJSONGraphNode(
             if (isDistinct) {
                 message = wrapNode(message, mType, mType ? message.value : message);
                 sizeOffset = getSize(node) - getSize(message);
-                node = replaceNode(node, message, parent, key, lru);
+                node = replaceNode(node, message, parent, key, lru, replacedPaths);
                 parent = updateNodeAncestors(parent, sizeOffset, lru, version);
                 node = insertNode(node, parent, key, version, optimizedPath);
             }

--- a/lib/support/mergeValueOrInsertBranch.js
+++ b/lib/support/mergeValueOrInsertBranch.js
@@ -19,7 +19,7 @@ var reconstructPath = require("./../support/reconstructPath");
 module.exports = function mergeValueOrInsertBranch(
     parent, node, key, value,
     branch, reference, requestedPath, optimizedPath,
-    version, expired, lru, comparator, errorSelector) {
+    version, expired, lru, comparator, errorSelector, replacedPaths) {
 
     var type = getType(node, reference);
 
@@ -29,7 +29,7 @@ module.exports = function mergeValueOrInsertBranch(
             expireNode(node, expired, lru);
         }
         if ((type && type !== $ref) || isPrimitive(node)) {
-            node = replaceNode(node, {}, parent, key, lru);
+            node = replaceNode(node, {}, parent, key, lru, replacedPaths);
             node = insertNode(node, parent, key, version, optimizedPath);
             node = updateBackReferenceVersions(node, version);
         }
@@ -58,7 +58,7 @@ module.exports = function mergeValueOrInsertBranch(
 
             var sizeOffset = getSize(node) - getSize(message);
 
-            node = replaceNode(node, message, parent, key, lru);
+            node = replaceNode(node, message, parent, key, lru, replacedPaths);
             parent = updateNodeAncestors(parent, sizeOffset, lru, version);
             node = insertNode(node, parent, key, version, optimizedPath);
         }

--- a/lib/support/removeNodeAndDescendants.js
+++ b/lib/support/removeNodeAndDescendants.js
@@ -2,16 +2,16 @@ var hasOwn = require("./../support/hasOwn");
 var prefix = require("./../internal/reservedPrefix");
 var removeNode = require("./../support/removeNode");
 
-module.exports = function removeNodeAndDescendants(node, parent, key, lru, replacedPaths) {
+module.exports = function removeNodeAndDescendants(node, parent, key, lru, mergeContext) {
     if (removeNode(node, parent, key, lru)) {
-        if (node.$type !== undefined && replacedPaths && node.$_absolutePath) {
-            replacedPaths.push(node.$_absolutePath);
+        if (node.$type !== undefined && mergeContext && node.$_absolutePath) {
+            mergeContext.hasInvalidatedResult = true;
         }
 
         if (node.$type == null) {
             for (var key2 in node) {
                 if (key2[0] !== prefix && hasOwn(node, key2)) {
-                    removeNodeAndDescendants(node[key2], node, key2, lru, replacedPaths);
+                    removeNodeAndDescendants(node[key2], node, key2, lru, mergeContext);
                 }
             }
         }

--- a/lib/support/removeNodeAndDescendants.js
+++ b/lib/support/removeNodeAndDescendants.js
@@ -2,12 +2,16 @@ var hasOwn = require("./../support/hasOwn");
 var prefix = require("./../internal/reservedPrefix");
 var removeNode = require("./../support/removeNode");
 
-module.exports = function removeNodeAndDescendants(node, parent, key, lru) {
+module.exports = function removeNodeAndDescendants(node, parent, key, lru, replacedPaths) {
     if (removeNode(node, parent, key, lru)) {
+        if (node.$type !== undefined && replacedPaths && node.$_absolutePath) {
+            replacedPaths.push(node.$_absolutePath);
+        }
+
         if (node.$type == null) {
             for (var key2 in node) {
                 if (key2[0] !== prefix && hasOwn(node, key2)) {
-                    removeNodeAndDescendants(node[key2], node, key2, lru);
+                    removeNodeAndDescendants(node[key2], node, key2, lru, replacedPaths);
                 }
             }
         }

--- a/lib/support/replaceNode.js
+++ b/lib/support/replaceNode.js
@@ -2,12 +2,12 @@ var isObject = require("./../support/isObject");
 var transferBackReferences = require("./../support/transferBackReferences");
 var removeNodeAndDescendants = require("./../support/removeNodeAndDescendants");
 
-module.exports = function replaceNode(node, replacement, parent, key, lru) {
+module.exports = function replaceNode(node, replacement, parent, key, lru, replacedPaths) {
     if (node === replacement) {
         return node;
     } else if (isObject(node)) {
         transferBackReferences(node, replacement);
-        removeNodeAndDescendants(node, parent, key, lru);
+        removeNodeAndDescendants(node, parent, key, lru, replacedPaths);
     }
 
     parent[key] = replacement;

--- a/lib/support/replaceNode.js
+++ b/lib/support/replaceNode.js
@@ -2,12 +2,12 @@ var isObject = require("./../support/isObject");
 var transferBackReferences = require("./../support/transferBackReferences");
 var removeNodeAndDescendants = require("./../support/removeNodeAndDescendants");
 
-module.exports = function replaceNode(node, replacement, parent, key, lru, replacedPaths) {
+module.exports = function replaceNode(node, replacement, parent, key, lru, mergeContext) {
     if (node === replacement) {
         return node;
     } else if (isObject(node)) {
         transferBackReferences(node, replacement);
-        removeNodeAndDescendants(node, parent, key, lru, replacedPaths);
+        removeNodeAndDescendants(node, parent, key, lru, mergeContext);
     }
 
     parent[key] = replacement;


### PR DESCRIPTION
The scenario which exposed this bug was receiving an error for some set of paths (likely due to loss of connection), merging a mix of errors and atoms with varying expiry, then successfully retrying a set of expired paths sharing the structure with non-expired paths. Explicit invalidation serves the same purpose as differing expiry, however.

The root cause was the mutable nature of pending json output, coupled with not blacklisting the $__path property. If something that was previously at a deep branch structure [lolomo, 0, 0, item, title] and expired/was invalidated resulting in a datasource request, upon merging into the output json the $__path field (which is an alias for $_absolutePath on cache nodes) would be partially overwritten, resulting in corrupted paths.

The solution was to blacklist $__path on merging into the json response, and retrying all paths with a fresh json seed if we detect any parts of the cache deleted and replaced with a different structure as a result of a server response.

I'm not super happy about this solution but it's the simplest I can immediately think of. Particularly, it involves sending yet another argument into our already bloated function signatures, "replacedPaths", and appending them to our missing paths during the get request cycle. I'm open to other ideas, but the implementation was straightforward if ugly.