### PR TITLE
partial request deduping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,7 +78,7 @@
         "no-throw-literal": [ 2 ],
         "no-unused-expressions": [ 2 ],
 
-        "no-warning-comments": [ 1 ],
+        "no-warning-comments": [ 0 ],
         "no-with": [ 2 ],
         "radix": [ 2 ],
         "wrap-iife": [ 2 ],

--- a/lib/get/onMissing.js
+++ b/lib/get/onMissing.js
@@ -31,15 +31,15 @@ module.exports = function onMissing(model, path, depth,
 
 function concatAndInsertMissing(model, remainingPath, depth, requestedPath,
                                 optimizedPath, optimizedLength, results) {
-
     // TODO: Performance.
     results.requestedMissingPaths.push(
         requestedPath.
             slice(0, depth).
             concat(remainingPath));
 
-    results.optimizedMissingPaths.push(
-        optimizedPath.slice(0, optimizedLength).concat(remainingPath));
+    var optimized = optimizedPath.slice(0, optimizedLength).concat(remainingPath);
+    optimized.depthDifferenceFromRequested = depth - optimizedLength;
+    results.optimizedMissingPaths.push(optimized);
 }
 
 function isEmptyAtom(atom) {

--- a/lib/get/onMissing.js
+++ b/lib/get/onMissing.js
@@ -1,7 +1,7 @@
 var support = require("./util/support");
 var fastCopy = support.fastCopy;
 var fastCat = support.fastCat;
-var arraySlice = require('./../support/array-slice');
+var arraySlice = require("./../support/array-slice");
 
 module.exports = function onMissing(model, path, depth,
                                     outerResults, requestedPath,

--- a/lib/get/onMissing.js
+++ b/lib/get/onMissing.js
@@ -1,5 +1,7 @@
 var support = require("./util/support");
 var fastCopy = support.fastCopy;
+var fastCat = support.fastCat;
+var arraySlice = require('./../support/array-slice');
 
 module.exports = function onMissing(model, path, depth,
                                     outerResults, requestedPath,
@@ -8,6 +10,7 @@ module.exports = function onMissing(model, path, depth,
     if (!outerResults.requestedMissingPaths) {
         outerResults.requestedMissingPaths = [];
         outerResults.optimizedMissingPaths = [];
+        outerResults.depthDifferences = [];
     }
 
     if (depth < path.length) {
@@ -31,15 +34,13 @@ module.exports = function onMissing(model, path, depth,
 
 function concatAndInsertMissing(model, remainingPath, depth, requestedPath,
                                 optimizedPath, optimizedLength, results) {
-    // TODO: Performance.
-    results.requestedMissingPaths.push(
-        requestedPath.
-            slice(0, depth).
-            concat(remainingPath));
+    results.requestedMissingPaths[results.requestedMissingPaths.length] =
+        fastCat(arraySlice(requestedPath, 0, depth), remainingPath);
 
-    var optimized = optimizedPath.slice(0, optimizedLength).concat(remainingPath);
-    optimized.depthDifferenceFromRequested = depth - optimizedLength;
-    results.optimizedMissingPaths.push(optimized);
+    results.optimizedMissingPaths[results.optimizedMissingPaths.length] =
+        fastCat(arraySlice(optimizedPath, 0, optimizedLength), remainingPath);
+
+    results.depthDifferences[results.depthDifferences.length] = depth - optimizedLength;
 }
 
 function isEmptyAtom(atom) {

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -140,7 +140,7 @@ GetRequestV2.prototype = {
         // If the out paths is less than the passed in paths, then there
         // has been an intersection and the complement has been returned.
         // Therefore, this can be deduped across requests.
-        if (optimizedComplement.length < optimized.length) {
+        if (complementTuple[0].length) {
             inserted = true;
             var idx = self._callbacks.length;
             self._callbacks[idx] = callback;

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -137,10 +137,9 @@ GetRequestV2.prototype = {
         var inserted = false;
         var disposable = false;
 
-        // If the out paths is less than the passed in paths, then there
-        // has been an intersection and the complement has been returned.
-        // Therefore, this can be deduped across requests.
-        if (complementTuple[0].length) {
+        // If we found an intersection, then just add new callback
+        // as one of the dependents of that request
+        if (complementTuple && complementTuple[0].length) {
             inserted = true;
             var idx = self._callbacks.length;
             self._callbacks[idx] = callback;

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -119,10 +119,12 @@ GetRequestV2.prototype = {
      *
      * @returns {Array} - the remaining paths in the request.
      */
-    add: function(requested, optimized, callback) {
+    add: function(requested, optimized, depthDifferences, callback) {
         // uses the length tree complement calculator.
         var self = this;
-        var complementTuple = complement(requested, optimized, self._pathMap);
+        console.log("requested", requested); // eslint-disable-line
+        console.log("optimized", optimized); // eslint-disable-line
+        var complementTuple = complement(requested, optimized, depthDifferences, self._pathMap);
         var optimizedComplement;
         var requestedComplement;
 

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -116,8 +116,11 @@ GetRequestV2.prototype = {
     /**
      * Attempts to add paths to the outgoing request.  If there are added
      * paths then the request callback will be added to the callback list.
+     * Handles adding partial paths as well
      *
-     * @returns {Array} - the remaining paths in the request.
+     * @returns {Array} - whether new requested paths were inserted in this
+     *                    request, the remaining paths that could not be added,
+     *                    and disposable for the inserted requested paths.
      */
     add: function(requested, optimized, depthDifferences, callback) {
         // uses the length tree complement calculator.

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -122,8 +122,6 @@ GetRequestV2.prototype = {
     add: function(requested, optimized, depthDifferences, callback) {
         // uses the length tree complement calculator.
         var self = this;
-        console.log("requested", requested); // eslint-disable-line
-        console.log("optimized", optimized); // eslint-disable-line
         var complementTuple = complement(requested, optimized, depthDifferences, self._pathMap);
         var optimizedComplement;
         var requestedComplement;

--- a/lib/request/RequestQueueV2.js
+++ b/lib/request/RequestQueueV2.js
@@ -43,7 +43,7 @@ RequestQueueV2.prototype = {
      * @param {Array} optimizedPaths -
      * @param {Function} cb -
      */
-    get: function(requestedPaths, optimizedPaths, cb) {
+    get: function(requestedPaths, optimizedPaths, depthDifferences, cb) {
         var self = this;
         var disposables = [];
         var count = 0;
@@ -64,7 +64,7 @@ RequestQueueV2.prototype = {
             // if possible.
             if (request.sent) {
                 var results = request.add(
-                    rRemainingPaths, oRemainingPaths, refCountCallback);
+                    rRemainingPaths, oRemainingPaths, depthDifferences, refCountCallback);
 
                 // Checks to see if the results were successfully inserted
                 // into the outgoing results.  Then our paths will be reduced

--- a/lib/request/complement.js
+++ b/lib/request/complement.js
@@ -4,11 +4,46 @@ var arrayConcat = require("./../support/array-concat");
 var iterateKeySet = require("falcor-path-utils").iterateKeySet;
 
 /**
- * creates the complement of the requested and optimized paths
- * based on the provided tree.
+ * Figures out what paths in requested pathsets can be
+ * deduped based on existing optimized path tree provided.
  *
- * If there is no complement then this is just a glorified
- * array copy.
+ * ## no deduping possible:
+ *
+ * if no existing requested sub tree at all for path,
+ * just add the entire path to complement.
+ *
+ * ## fully deduped:
+ *
+ * if required path is a complete subset of given sub tree,
+ * just add the entire path to intersection
+ *
+ * ## partial deduping:
+ *
+ * if some part of path, when ranges are expanded, is a subset
+ * of given sub tree, then add only that part to intersection,
+ * and all other parts of this path to complement
+ *
+ * To keep `depth` argument be a valid index for optimized path (`oPath`),
+ * either requested or optimized path is sent in pre-initialized with
+ * some items so that their remaining length matches exactly, keeping
+ * remaining ranges in those pathsets 1:1 in correspondence
+ *
+ * Note that positive `depthDiff` value means that requested path is
+ * longer than optimized path, and we need to pre-initialize current
+ * requested path with that many offset items, so that their remaining
+ * length matches. Similarly, negative `depthDiff` value means that
+ * optimized path is longer, and we pre-initialize optimized path with
+ * those many items. Note that because of the way requested and
+ * optimized paths are accumulated from what user requested in model.get
+ * (see onMissing.js), it is not possible for the pre-initialized paths
+ * to have any ranges in them.
+ *
+ * `intersectionData` is:
+ * [ requestedIntersection, optimizedComplement, requestedComplement ]
+ * where `requestedIntersection` is matched requested paths that can be
+ * deduped, `optimizedComplement` is missing optimized paths, and
+ * `requestedComplement` is requested counterparts of those missing
+ * optimized paths
  */
 module.exports = function complement(requested, optimized, depthDifferences, tree) {
     var optimizedComplement = [];
@@ -17,36 +52,24 @@ module.exports = function complement(requested, optimized, depthDifferences, tre
     var intersectionLength = -1, complementLength = -1;
 
     for (var i = 0, len = optimized.length; i < len; ++i) {
-        // If this does not intersect then add it to the output.
         var oPath = optimized[i];
         var rPath = requested[i];
         var depthDiff = depthDifferences[i];
         var subTree = tree[oPath.length];
 
-        // if no existing requested sub tree at all for path,
-        // just add the entire path to complement
-        // (no deduping possible)
+        // no deduping possible
         if (!subTree) {
             optimizedComplement[++complementLength] = oPath;
             requestedComplement[complementLength] = rPath;
             continue;
         }
-        // if required path is a complete subset of given sub tree,
-        // just add the entire path to intersection
-        // (fully deduped)
+        // fully deduped
         if (hasIntersection(subTree, oPath, 0)) {
             requestedIntersection[++intersectionLength] = rPath;
             continue;
         }
-        // if some part of path, when ranges are expanded, is a subset
-        // of given sub tree, then add only that part to intersection,
-        // and all other parts of this path to complement
 
-        // intersectionData is:
-        // [ requestedIntersection, optimizedComplement, requestedComplement ]
-        // where requestedIntersection is matched requested paths for , and
-        // complements is paths not found, from the total set of
-        // individual paths (all ranges expanded)
+        // partial deduping
         var intersectionData = findPartialIntersections(
             rPath,
             oPath,
@@ -70,38 +93,79 @@ module.exports = function complement(requested, optimized, depthDifferences, tre
     return [requestedIntersection, optimizedComplement, requestedComplement];
 };
 
+/**
+ * Recursive function to calculate intersection and complement paths in 2 given
+ * pathsets at a given depth
+ * Parameters:
+ *  - `requestedPath`: full requested path (can include ranges)
+ *  - `optimizedPath`: corresponding optimized path (can include ranges)
+ *  - `currentTree`: path map for in-flight request, against which to dedupe
+ *  - `depth`: index of optimized path that we are trying to match with `currentTree`
+ *  - `rCurrentPath`: current accumulated requested path by previous recursive
+ *                    iterations. Could also have been pre-initialized as stated
+ *                    above.
+ *                    This path cannot contain ranges, instead contains a key
+ *                    from the range, representing one of the individual paths
+ *                    in `requestedPath` pathset
+ *  - `oCurrentPath`: corresponding accumulated optimized path, to be matched
+ *                    with `currentTree`. Could have been pre-initialized.
+ *                    Cannot contain ranges, instead contains a key from the
+ *                    range at given `depth` in `optimizedPath`
+ *  - `depthDiff`: difference in length between `requestedPath` and `optimizedPath`
+ *
+ *  Example scenario:
+ *      - requestedPath: ['lolomo', 0, 0, 'tags', { from: 0, to: 2 }]
+ *      - optimizedPath: ['videosById', 11, 'tags', { from: 0, to: 2 }]
+ *      - currentTree: { videosById: 11: { tags: { 0: null, 1: null }}}
+ *      // since requested path is longer, optimized path index starts from depth 0
+ *      // and accumulated requested path starts pre-initialized (rCurrentPath)
+ *      - depth: 0
+ *      - rCurrentPath: ['lolomo']
+ *      - oCurrentPath: []
+ *      - depthDiff: 1
+ */
 function findPartialIntersections(requestedPath, optimizedPath, currentTree, depth, rCurrentPath, oCurrentPath, depthDiff) {
     var intersections = [];
-    var rRemainingComplementPaths = [];
-    var oRemainingComplementPaths = [];
+    var rComplementPaths = [];
+    var oComplementPaths = [];
+    // iterate over optimized path, looking for deduping opportunities
     for (; depth < optimizedPath.length; ++depth) {
         var key = optimizedPath[depth];
         var keyType = typeof key;
 
-        // range keys
+        // if range key is found, start inner loop to iterate over all keys in range
+        // and add intersections and complements from each iteration separately.
+        // range keys branch-out like this, providing individual deduping
+        // opportunities for each inner key
         if (key && keyType === "object") {
             var note = {};
             var innerKey = iterateKeySet(key, note);
 
             while (!note.done) {
                 var nextTree = currentTree[innerKey];
-                // dead-end for sub paths innerKey & beyond
                 if (nextTree === undefined) {
-                    var oRemainingPath = oCurrentPath.concat(
+                    // if no next sub tree exists for an inner key, it's a dead-end
+                    // and we can add this to complement paths
+                    var oPath = oCurrentPath.concat(
                         innerKey,
                         arraySlice(
                             optimizedPath,
                             depth + 1));
-                    oRemainingComplementPaths[oRemainingComplementPaths.length] = oRemainingPath;
-                    var rRemainingPath = rCurrentPath.concat(
+                    oComplementPaths[oComplementPaths.length] = oPath;
+                    var rPath = rCurrentPath.concat(
                         innerKey,
                         arraySlice(
                             requestedPath,
                             depth + 1 + depthDiff));
-                    rRemainingComplementPaths[rRemainingComplementPaths.length] = rRemainingPath;
+                    rComplementPaths[rComplementPaths.length] = rPath;
                 } else if (depth === optimizedPath.length - 1) {
+                    // reaching the end of optimized path means that we found a
+                    // corresponding node in the path map tree every time,
+                    // so add current path to successful intersections
                     intersections[intersections.length] = arrayConcat(rCurrentPath, [innerKey]);
                 } else {
+                    // otherwise keep trying to find further partial deduping
+                    // opportunities in the remaining path!
                     var intersectionData = findPartialIntersections(
                         requestedPath,
                         optimizedPath,
@@ -114,29 +178,36 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
                         intersections[intersections.length] = intersectionData[0][j];
                     }
                     for (var k = 0, kLen = intersectionData[1].length; k < kLen; ++k) {
-                        oRemainingComplementPaths[oRemainingComplementPaths.length] = intersectionData[1][k];
-                        rRemainingComplementPaths[rRemainingComplementPaths.length] = intersectionData[2][k];
+                        oComplementPaths[oComplementPaths.length] = intersectionData[1][k];
+                        rComplementPaths[rComplementPaths.length] = intersectionData[2][k];
                     }
                 }
                 innerKey = iterateKeySet(key, note);
             }
             break;
         }
-        // simple keys
+
+        // for simple keys, we don't need to branch out. looping over `depth`
+        // here instead of recursion, for performance
         currentTree = currentTree[key];
         oCurrentPath[oCurrentPath.length] = optimizedPath[depth];
         rCurrentPath[rCurrentPath.length] = requestedPath[depth + depthDiff];
+
         if (currentTree === undefined) {
-            oRemainingComplementPaths[oRemainingComplementPaths.length] =
+            // if dead-end, add this to complements
+            oComplementPaths[oComplementPaths.length] =
                 arrayConcat(oCurrentPath, arraySlice(optimizedPath, depth + 1));
-            rRemainingComplementPaths[rRemainingComplementPaths.length] =
+            rComplementPaths[rComplementPaths.length] =
                 arrayConcat(rCurrentPath, arraySlice(requestedPath, depth + depthDiff + 1));
             break;
         } else if (depth === optimizedPath.length - 1) {
+            // if reach end of optimized path successfully, add to intersections
             intersections[intersections.length] = rCurrentPath;
         }
+        // otherwise keep going
     }
 
-    return [intersections, oRemainingComplementPaths, rRemainingComplementPaths];
+    // return accumulated intersection and complement pathsets
+    return [intersections, oComplementPaths, rComplementPaths];
 }
 

--- a/lib/request/complement.js
+++ b/lib/request/complement.js
@@ -51,7 +51,7 @@ module.exports = function complement(requested, optimized, depthDifferences, tre
             rPath,
             oPath,
             subTree,
-            0,
+            depthDiff < 0 ? -depthDiff : 0,
             depthDiff > 0 ? arraySlice(rPath, 0, depthDiff) : [],
             depthDiff < 0 ? arraySlice(oPath, 0, -depthDiff) : [],
             depthDiff);
@@ -124,7 +124,6 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
         }
         // simple keys
         currentTree = currentTree[key];
-        // TODO: recheck this. might have to be different for depthDiff > or < 0
         oCurrentPath[oCurrentPath.length] = optimizedPath[depth];
         rCurrentPath[rCurrentPath.length] = requestedPath[depth + depthDiff];
         if (currentTree === undefined) {

--- a/lib/request/complement.js
+++ b/lib/request/complement.js
@@ -1,7 +1,7 @@
 var hasIntersection = require("falcor-path-utils").hasIntersection;
 var arraySlice = require("./../support/array-slice");
 var arrayConcat = require("./../support/array-concat");
-var iterateKeySet = require('falcor-path-utils').iterateKeySet;
+var iterateKeySet = require("falcor-path-utils").iterateKeySet;
 
 /**
  * creates the complement of the requested and optimized paths
@@ -10,7 +10,7 @@ var iterateKeySet = require('falcor-path-utils').iterateKeySet;
  * If there is no complement then this is just a glorified
  * array copy.
  */
-module.exports = function complement(requested, optimized, tree) {
+module.exports = function complement(requested, optimized, depthDifferences, tree) {
     var optimizedComplement = [];
     var requestedComplement = [];
     var requestedIntersection = [];
@@ -20,6 +20,7 @@ module.exports = function complement(requested, optimized, tree) {
         // If this does not intersect then add it to the output.
         var oPath = optimized[i];
         var rPath = requested[i];
+        var depthDiff = depthDifferences[i];
         var subTree = tree[oPath.length];
 
         // if no existing requested sub tree at all for path,
@@ -46,20 +47,20 @@ module.exports = function complement(requested, optimized, tree) {
         // where requestedIntersection is matched requested paths for , and
         // complements is paths not found, from the total set of
         // individual paths (all ranges expanded)
-        var depthDiff = oPath.depthDifferenceFromRequested;
         var intersectionData = findPartialIntersections(
             rPath,
             oPath,
             subTree,
             0,
             depthDiff > 0 ? arraySlice(rPath, 0, depthDiff) : [],
-            depthDiff < 0 ? arraySlice(oPath, 0, depthDiff) : []);
+            depthDiff < 0 ? arraySlice(oPath, 0, depthDiff) : [],
+            depthDiff);
         for (var j = 0, jLen = intersectionData[0].length; j < jLen; ++j) {
             requestedIntersection[++intersectionLength] = intersectionData[0][j];
         }
-        for (var j = 0, jLen = intersectionData[1].length; j < jLen; ++j) {
-            optimizedComplement[++complementLength] = intersectionData[1][j];
-            requestedComplement[complementLength] = intersectionData[2][j];
+        for (var k = 0, kLen = intersectionData[1].length; k < kLen; ++k) {
+            optimizedComplement[++complementLength] = intersectionData[1][k];
+            requestedComplement[complementLength] = intersectionData[2][k];
         }
     }
 
@@ -69,17 +70,16 @@ module.exports = function complement(requested, optimized, tree) {
     return [requestedIntersection, optimizedComplement, requestedComplement];
 };
 
-function findPartialIntersections(requestedPath, optimizedPath, currentTree, depth, rCurrentPath, oCurrentPath) {
+function findPartialIntersections(requestedPath, optimizedPath, currentTree, depth, rCurrentPath, oCurrentPath, depthDiff) {
     var intersections = [];
     var rRemainingComplementPaths = [];
     var oRemainingComplementPaths = [];
-    var oPathDepthDifference = optimizedPath.depthDifferenceFromRequested;
     for (; depth < optimizedPath.length; ++depth) {
         var key = optimizedPath[depth];
         var keyType = typeof key;
 
         // range keys
-        if (key && keyType === 'object') {
+        if (key && keyType === "object") {
             var note = {};
             var innerKey = iterateKeySet(key, note);
 
@@ -97,7 +97,7 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
                         innerKey,
                         arraySlice(
                             requestedPath,
-                            depth + 1 + oPathDepthDifference));
+                            depth + 1 + depthDiff));
                     rRemainingComplementPaths[rRemainingComplementPaths.length] = rRemainingPath;
                 } else if (depth === optimizedPath.length - 1) {
                     intersections[intersections.length] = arrayConcat(rCurrentPath, [innerKey]);
@@ -108,9 +108,15 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
                         nextTree,
                         depth + 1,
                         arrayConcat(rCurrentPath, [innerKey]),
-                        arrayConcat(oCurrentPath, [innerKey]));
-                    // TODO: add results to result array
-
+                        arrayConcat(oCurrentPath, [innerKey]),
+                        depthDiff);
+                    for (var j = 0, jLen = intersectionData[0].length; j < jLen; ++j) {
+                        intersections[intersections.length] = intersectionData[0][j];
+                    }
+                    for (var k = 0, kLen = intersectionData[1].length; k < kLen; ++k) {
+                        oRemainingComplementPaths[oRemainingComplementPaths.length] = intersectionData[1][k];
+                        rRemainingComplementPaths[rRemainingComplementPaths.length] = intersectionData[2][k];
+                    }
                 }
                 innerKey = iterateKeySet(key, note);
             }
@@ -119,10 +125,12 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
         // simple keys
         currentTree = currentTree[key];
         oCurrentPath[oCurrentPath.length] = optimizedPath[depth];
-        rCurrentPath[rCurrentPath.length] = requestedPath[depth + oPathDepthDifference];
+        rCurrentPath[rCurrentPath.length] = requestedPath[depth + depthDiff];
         if (currentTree === undefined) {
-            rRemainingComplementPaths[rRemainingComplementPaths.length] = rCurrentPath;
-            oRemainingComplementPaths[oRemainingComplementPaths.length] = oCurrentPath;
+            rRemainingComplementPaths[rRemainingComplementPaths.length] =
+                arrayConcat(rCurrentPath, arraySlice(requestedPath, depth + depthDiff + 1));
+            oRemainingComplementPaths[oRemainingComplementPaths.length] =
+                arrayConcat(oCurrentPath, arraySlice(optimizedPath, depth + 1));
             break;
         } else if (depth === optimizedPath.length - 1) {
             intersections[intersections.length] = rCurrentPath;

--- a/lib/request/complement.js
+++ b/lib/request/complement.js
@@ -1,5 +1,7 @@
 var hasIntersection = require("falcor-path-utils").hasIntersection;
 var arraySlice = require("./../support/array-slice");
+var arrayConcat = require("./../support/array-concat");
+var iterateKeySet = require('falcor-path-utils').iterateKeySet;
 
 /**
  * creates the complement of the requested and optimized paths
@@ -13,38 +15,120 @@ module.exports = function complement(requested, optimized, tree) {
     var requestedComplement = [];
     var requestedIntersection = [];
     var intersectionLength = -1, complementLength = -1;
-    var intersectionFound = false;
 
     for (var i = 0, len = optimized.length; i < len; ++i) {
         // If this does not intersect then add it to the output.
-        var path = optimized[i];
-        var subTree = tree[path.length];
+        var oPath = optimized[i];
+        var rPath = requested[i];
+        var subTree = tree[oPath.length];
 
-        // If there is no subtree to look into or there is no intersection.
-        if (!subTree || !hasIntersection(subTree, path, 0)) {
+        // if no existing requested sub tree at all for path,
+        // just add the entire path to complement
+        // (no deduping possible)
+        if (!subTree) {
+            optimizedComplement[++complementLength] = oPath;
+            requestedComplement[complementLength] = rPath;
+            continue;
+        }
+        // if required path is a complete subset of given sub tree,
+        // just add the entire path to intersection
+        // (fully deduped)
+        if (hasIntersection(subTree, oPath, 0)) {
+            requestedIntersection[++intersectionLength] = rPath;
+            continue;
+        }
+        // if some part of path, when ranges are expanded, is a subset
+        // of given sub tree, then add only that part to intersection,
+        // and all other parts of this path to complement
 
-            if (intersectionFound) {
-                optimizedComplement[++complementLength] = path;
-                requestedComplement[complementLength] = requested[i];
-            }
-        } else {
-            // If there has been no intersection yet and
-            // i is bigger than 0 (meaning we have had only complements)
-            // then we need to update our complements to match the current
-            // reality.
-            if (!intersectionFound && i > 0) {
-                requestedComplement = arraySlice(requested, 0, i);
-                optimizedComplement = arraySlice(optimized, 0, i);
-            }
-
-            requestedIntersection[++intersectionLength] = requested[i];
-            intersectionFound = true;
+        // intersectionData is:
+        // [ requestedIntersection, optimizedComplement, requestedComplement ]
+        // where requestedIntersection is matched requested paths for , and
+        // complements is paths not found, from the total set of
+        // individual paths (all ranges expanded)
+        var depthDiff = oPath.depthDifferenceFromRequested;
+        var intersectionData = findPartialIntersections(
+            rPath,
+            oPath,
+            subTree,
+            0,
+            depthDiff > 0 ? arraySlice(rPath, 0, depthDiff) : [],
+            depthDiff < 0 ? arraySlice(oPath, 0, depthDiff) : []);
+        for (var j = 0, jLen = intersectionData[0].length; j < jLen; ++j) {
+            requestedIntersection[++intersectionLength] = intersectionData[0][j];
+        }
+        for (var j = 0, jLen = intersectionData[1].length; j < jLen; ++j) {
+            optimizedComplement[++complementLength] = intersectionData[1][j];
+            requestedComplement[complementLength] = intersectionData[2][j];
         }
     }
 
-    if (!intersectionFound) {
+    if (!requestedIntersection.length) {
         return null;
     }
-
-    return [requestedIntersection, optimizedComplement, requestedComplement ];
+    return [requestedIntersection, optimizedComplement, requestedComplement];
 };
+
+function findPartialIntersections(requestedPath, optimizedPath, currentTree, depth, rCurrentPath, oCurrentPath) {
+    var intersections = [];
+    var rRemainingComplementPaths = [];
+    var oRemainingComplementPaths = [];
+    var oPathDepthDifference = optimizedPath.depthDifferenceFromRequested;
+    for (; depth < optimizedPath.length; ++depth) {
+        var key = optimizedPath[depth];
+        var keyType = typeof key;
+
+        // range keys
+        if (key && keyType === 'object') {
+            var note = {};
+            var innerKey = iterateKeySet(key, note);
+
+            while (!note.done) {
+                var nextTree = currentTree[innerKey];
+                // dead-end for sub paths innerKey & beyond
+                if (nextTree === undefined) {
+                    var oRemainingPath = oCurrentPath.concat(
+                        innerKey,
+                        arraySlice(
+                            optimizedPath,
+                            depth + 1));
+                    oRemainingComplementPaths[oRemainingComplementPaths.length] = oRemainingPath;
+                    var rRemainingPath = rCurrentPath.concat(
+                        innerKey,
+                        arraySlice(
+                            requestedPath,
+                            depth + 1 + oPathDepthDifference));
+                    rRemainingComplementPaths[rRemainingComplementPaths.length] = rRemainingPath;
+                } else if (depth === optimizedPath.length - 1) {
+                    intersections[intersections.length] = arrayConcat(rCurrentPath, [innerKey]);
+                } else {
+                    var intersectionData = findPartialIntersections(
+                        requestedPath,
+                        optimizedPath,
+                        nextTree,
+                        depth + 1,
+                        arrayConcat(rCurrentPath, [innerKey]),
+                        arrayConcat(oCurrentPath, [innerKey]));
+                    // TODO: add results to result array
+
+                }
+                innerKey = iterateKeySet(key, note);
+            }
+            break;
+        }
+        // simple keys
+        currentTree = currentTree[key];
+        oCurrentPath[oCurrentPath.length] = optimizedPath[depth];
+        rCurrentPath[rCurrentPath.length] = requestedPath[depth + oPathDepthDifference];
+        if (currentTree === undefined) {
+            rRemainingComplementPaths[rRemainingComplementPaths.length] = rCurrentPath;
+            oRemainingComplementPaths[oRemainingComplementPaths.length] = oCurrentPath;
+            break;
+        } else if (depth === optimizedPath.length - 1) {
+            intersections[intersections.length] = rCurrentPath;
+        }
+    }
+
+    return [intersections, oRemainingComplementPaths, rRemainingComplementPaths];
+}
+

--- a/lib/request/complement.js
+++ b/lib/request/complement.js
@@ -53,7 +53,7 @@ module.exports = function complement(requested, optimized, depthDifferences, tre
             subTree,
             0,
             depthDiff > 0 ? arraySlice(rPath, 0, depthDiff) : [],
-            depthDiff < 0 ? arraySlice(oPath, 0, depthDiff) : [],
+            depthDiff < 0 ? arraySlice(oPath, 0, -depthDiff) : [],
             depthDiff);
         for (var j = 0, jLen = intersectionData[0].length; j < jLen; ++j) {
             requestedIntersection[++intersectionLength] = intersectionData[0][j];
@@ -124,13 +124,14 @@ function findPartialIntersections(requestedPath, optimizedPath, currentTree, dep
         }
         // simple keys
         currentTree = currentTree[key];
+        // TODO: recheck this. might have to be different for depthDiff > or < 0
         oCurrentPath[oCurrentPath.length] = optimizedPath[depth];
         rCurrentPath[rCurrentPath.length] = requestedPath[depth + depthDiff];
         if (currentTree === undefined) {
-            rRemainingComplementPaths[rRemainingComplementPaths.length] =
-                arrayConcat(rCurrentPath, arraySlice(requestedPath, depth + depthDiff + 1));
             oRemainingComplementPaths[oRemainingComplementPaths.length] =
                 arrayConcat(oCurrentPath, arraySlice(optimizedPath, depth + 1));
+            rRemainingComplementPaths[rRemainingComplementPaths.length] =
+                arrayConcat(rCurrentPath, arraySlice(requestedPath, depth + depthDiff + 1));
             break;
         } else if (depth === optimizedPath.length - 1) {
             intersections[intersections.length] = rCurrentPath;

--- a/lib/response/get/checkCacheAndReport.js
+++ b/lib/response/get/checkCacheAndReport.js
@@ -6,6 +6,27 @@ var getWithPathsAsPathMap = gets.getWithPathsAsPathMap;
  * Checks cache for the paths and reports if in progressive mode.  If
  * there are missing paths then return the cache hit results.
  *
+ * Return value (`results`) stores missing path information as 3 index-linked arrays:
+ * `requestedMissingPaths` holds requested paths that were not found in cache
+ * `optimizedMissingPaths` holds optimized versions of requested paths
+ * `depthDifferences` holds the difference in length of requested and optimized paths
+ *
+ * Note that requestedMissingPaths is not necessarily the list of paths requested by
+ * user in model.get. It does not contain those paths that were found in
+ * cache. It also breaks some path sets out into separate paths, those which
+ * resolve to different optimized lengths after walking through any references in
+ * cache.
+ * This helps maintain a 1:1 correspondence between requested and optimized missing,
+ * as well as their depth differences (or, length offsets).
+ *
+ * Example: Given cache: `{ lolomo: { 0: $ref('vid'), 1: $ref('a.b.c.d') }}`,
+ * `model.get('lolomo[0..2].name').subscribe()` will result in the following
+ * corresponding values:
+ *    index   requestedMissingPaths   optimizedMissingPaths         depthDifferences
+ *      0     ['lolomo', 0, 'name']   ['vid', 'name']                   1
+ *      1     ['lolomo', 1, 'name']   ['a', 'b', 'c', 'd', 'name']     -2
+ *      2     ['lolomo', 2, 'name']   ['lolomo', 2, 'name']             0
+ *
  * @param {Model} model - The model that the request was made with.
  * @param {Array} requestedMissingPaths -
  * @param {Boolean} progressive -
@@ -14,6 +35,8 @@ var getWithPathsAsPathMap = gets.getWithPathsAsPathMap;
  * @param {Function} onError -
  * @param {Function} onCompleted -
  * @param {Object} seed - The state of the output
+ * @returns {Object} results -
+ *
  * @private
  */
 module.exports = function checkCacheAndReport(model, requestedPaths, observer,

--- a/lib/response/get/getRequestCycle.js
+++ b/lib/response/get/getRequestCycle.js
@@ -32,16 +32,19 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
     var requestQueue = model._request;
     var requestedMissingPaths = results.requestedMissingPaths;
     var optimizedMissingPaths = results.optimizedMissingPaths;
+    var depthDifferences = results.depthDifferences;
     var disposable = new AssignableDisposable();
 
     // We need to prepend the bound path to all requested missing paths and
     // pass those into the requestQueue.
     var boundRequestedMissingPaths = [];
     var boundPath = model._path;
+    var boundPathLength = boundPath.length;
     if (boundPath.length) {
         for (var i = 0, len = requestedMissingPaths.length; i < len; ++i) {
             boundRequestedMissingPaths[i] =
                 fastCat(boundPath, requestedMissingPaths[i]);
+            depthDifferences[i] += boundPathLength;
         }
     }
 
@@ -51,7 +54,7 @@ module.exports = function getRequestCycle(getResponse, model, results, observer,
     }
 
     var currentRequestDisposable = requestQueue.
-        get(boundRequestedMissingPaths, optimizedMissingPaths, function(err, data, hasInvalidatedResult) {
+        get(boundRequestedMissingPaths, optimizedMissingPaths, depthDifferences, function(err, data, hasInvalidatedResult) {
             if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
                 if (results.hasValues) {
                     observer.onNext(results.values && results.values[0]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -610,6 +610,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "browser-unpack": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browser-unpack/-/browser-unpack-1.2.0.tgz",
@@ -4488,6 +4494,93 @@
         "gulp-util": "3.0.8",
         "mocha": "1.21.5",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "dev": true,
+          "requires": {
+            "ms": "0.6.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "inherits": "2.0.3",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mocha": {
+          "version": "1.21.5",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
+          "integrity": "sha1-fFiwkXTfl25DSiOx6NY5hz/FKek=",
+          "dev": true,
+          "requires": {
+            "commander": "2.3.0",
+            "debug": "2.0.0",
+            "diff": "1.0.8",
+            "escape-string-regexp": "1.0.2",
+            "glob": "3.2.3",
+            "growl": "1.8.1",
+            "jade": "0.26.3",
+            "mkdirp": "0.5.0"
+          }
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+          "dev": true
+        }
       }
     },
     "gulp-rename": {
@@ -4772,6 +4865,12 @@
         "hoek": "2.16.3",
         "sntp": "1.0.9"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -6973,89 +7072,58 @@
       }
     },
     "mocha": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
-      "integrity": "sha1-fFiwkXTfl25DSiOx6NY5hz/FKek=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
       "requires": {
-        "commander": "2.3.0",
-        "debug": "2.0.0",
-        "diff": "1.0.8",
-        "escape-string-regexp": "1.0.2",
-        "glob": "3.2.3",
-        "growl": "1.8.1",
-        "jade": "0.26.3",
-        "mkdirp": "0.5.0"
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-          "dev": true
-        },
         "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "dev": true
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
+        },
+        "has-flag": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
-          "dev": true,
-          "requires": {
-            "ms": "0.6.2"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
-        "glob": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "2.0.3",
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "has-flag": "2.0.0"
           }
-        },
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "falcorjs"
   ],
   "devDependencies": {
+    "after": "^0.8.2",
     "benchmark": "^2.1.4",
     "body-parser": "^1.13.3",
     "browserify": "^14.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "scripts": {
     "test": "gulp test-coverage",
     "test:only": "mocha test/index.js",
+    "test:only:inspect": "mocha --inspect-brk test/index.js",
+    "lint": "gulp lint",
     "dist": "gulp all",
     "doc": "gulp doc",
     "perf": "gulp perf-run",
@@ -69,6 +71,7 @@
     "lodash": "^4.17.4",
     "minimist": "^1.1.0",
     "mkdirp": "^0.5.1",
+    "mocha": "^4.0.1",
     "promise": "8.0.1",
     "rx": "2.5.3",
     "rxjs": "^5.0.0-rc.1",

--- a/test/data/LocalDataSource.js
+++ b/test/data/LocalDataSource.js
@@ -96,7 +96,7 @@ LocalSource.prototype = {
                 observer.onCompleted();
             }
 
-            if (wait === false) {
+            if (wait === undefined) {
                 exec();
             } else {
                 setTimeout(exec, wait);

--- a/test/data/LocalDataSource.js
+++ b/test/data/LocalDataSource.js
@@ -10,7 +10,7 @@ var LocalSource = module.exports = function(cache, options) {
         onGet: noOp,
         onSet: noOp,
         onResults: noOp,
-        wait: false,
+        // wait: undefined,
         materialize: false
     }, options);
     this._missCount = 0;
@@ -61,7 +61,7 @@ LocalSource.prototype = {
                 observer.onNext(output);
                 observer.onCompleted();
             }
-            if (wait === false) {
+            if (wait === undefined) {
                 exec();
             } else {
                 setTimeout(exec, wait);

--- a/test/data/LocalDataSource.js
+++ b/test/data/LocalDataSource.js
@@ -35,7 +35,7 @@ LocalSource.prototype = {
         var miss = options.miss;
         var onGet = options.onGet;
         var onResults = options.onResults;
-        var wait = +options.wait;
+        var wait = options.wait;
         var errorSelector = options.errorSelector;
         return Rx.Observable.create(function(observer) {
             function exec() {
@@ -61,10 +61,10 @@ LocalSource.prototype = {
                 observer.onNext(output);
                 observer.onCompleted();
             }
-            if (wait > 0) {
-                setTimeout(exec, wait);
-            } else {
+            if (wait === false) {
                 exec();
+            } else {
+                setTimeout(exec, wait);
             }
         });
     },
@@ -74,7 +74,7 @@ LocalSource.prototype = {
         var miss = options.miss;
         var onSet = options.onSet;
         var onResults = options.onResults;
-        var wait = +options.wait;
+        var wait = options.wait;
         var errorSelector = options.errorSelector;
         return Rx.Observable.create(function(observer) {
             function exec() {
@@ -96,10 +96,10 @@ LocalSource.prototype = {
                 observer.onCompleted();
             }
 
-            if (wait > 0) {
-                setTimeout(exec, wait);
-            } else {
+            if (wait === false) {
                 exec();
+            } else {
+                setTimeout(exec, wait);
             }
         });
     },

--- a/test/integration/dedupe.spec.js
+++ b/test/integration/dedupe.spec.js
@@ -1,0 +1,202 @@
+var falcor = require('../../browser');
+var LocalDataSource = require('../data/LocalDataSource');
+var after = require('after');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var strip = require('../cleanData').stripDerefAndVersionKeys;
+var $ref = falcor.Model.ref;
+var noOp = function() {};
+
+describe('Request deduping', function() {
+    it('should dedupe new requested paths with previous in-flight requests', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2'
+                }
+            }, {
+                wait: 0, // wait: 0 means setTimeout 0
+                onGet: onGet
+            })
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', { from: 0, to: 1 }]).subscribe(function(response) {
+            expect(onGet.calledOnce).to.equal(true);
+            expect(onGet.getCall(0).args[1]).to.deep.equal([[ 'things', { from: 0, to: 1 } ]]);
+            expect(strip(response.json)).to.deep.equal({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1'
+                }
+            });
+        }, done, partDone);
+        model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
+            expect(onGet.calledTwice).to.equal(true);
+            expect(onGet.getCall(1).args[1]).to.deep.equal([[ 'things', '2' ]]);
+            expect(strip(response.json)).to.deep.equal({
+                things: {
+                    1: 'thing: 1',
+                    2: 'thing: 2'
+                }
+            });
+        }, done, partDone);
+    });
+
+    it('should dedupe from both ends of overlapping ranges', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2',
+                    3: 'thing: 3',
+                    4: 'thing: 4',
+                }
+            }, {
+                wait: 0,
+                onGet: onGet
+            })
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
+            expect(onGet.getCall(0).args[1]).to.deep.equal([[ 'things', { from: 1, to: 2 } ]]);
+        }, done, partDone);
+        model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
+            expect(onGet.getCall(1).args[1]).to.deep.equal([[ 'things', [0, 3, 4] ]]);
+        }, done, partDone);
+    });
+
+    it('should leave ranges unrolled if possible', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2',
+                    3: 'thing: 3',
+                    4: 'thing: 4',
+                }
+            }, {
+                wait: 0,
+                onGet: onGet
+            })
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', { from: 0, to: 2 }]).subscribe(noOp, done, partDone);
+        model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
+            expect(onGet.getCall(1).args[1]).to.deep.equal([[ 'things', { from: 3, to: 4 } ]]);
+        }, done, partDone);
+    });
+
+    it('should work for properties after ranges', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: { name: 'thing: 0' },
+                    1: { name: 'thing: 1' },
+                    2: { name: 'thing: 2' },
+                }
+            }, {
+                wait: 0,
+                onGet: onGet
+            })
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', { from: 0, to: 1 }, 'name']).subscribe(noOp, done, partDone);
+        model.get(['things', { from: 1, to: 2 }, 'name']).subscribe(function() {
+            expect(onGet.getCall(1).args[1]).to.deep.equal([[ 'things', 2, 'name' ]]);
+        }, done, partDone);
+    });
+
+    it('should work for multiple ranges in path sets', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: { name: 'thing: 0', tags: { 0: 't0 tag: 0', 1: 't0 tag: 1', 2: 't0 tag: 2' } },
+                    1: { name: 'thing: 1', tags: { 0: 't1 tag: 0', 1: 't1 tag: 1', 2: 't1 tag: 2' } },
+                    2: { name: 'thing: 2', tags: { 0: 't2 tag: 0', 1: 't2 tag: 1', 2: 't2 tag: 2' } },
+                }
+            }, {
+                wait: 0,
+                onGet: onGet
+            })
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', { from: 0, to: 1 }, 'tags', { from: 1, to: 2 }]).subscribe(noOp, done, partDone);
+        model.get(['things', { from: 0, to: 2 }, 'tags', { from: 0, to: 2 }]).subscribe(function() {
+            expect(onGet.getCall(1).args[1]).to.deep.equal([
+                ['things', { from: 0, to: 1 }, 'tags', '0'],
+                ['things', 2, 'tags', { from: 0, to: 2 }]
+            ]);
+        }, done, partDone);
+    });
+
+    it('should work when different optimized and requested path lengths', function(done) {
+        var onGet = sinon.spy();
+        var model = new falcor.Model({
+            source: new LocalDataSource({
+                things: {
+                    0: {
+                        tags: {
+                            0: 't0 tag: 0',
+                            1: 't0 tag: 1'
+                        }
+                    },
+                },
+                oneoff: {
+                    tags: {
+                        0: 't2 tag: 0',
+                        1: 't2 tag: 1'
+                    }
+                },
+                thang: {
+                    that: {
+                        really: {
+                            is: {
+                                a: {
+                                    thing: {
+                                        of: {
+                                            course: {
+                                                tags: {
+                                                    0: 'thang tag: 0',
+                                                    1: 'thang tag: 1' }}}}}}}}}
+            }, {
+                wait: 0,
+                onGet: onGet
+            }),
+            cache: {
+                things: {
+                    1: $ref('thang.that.really.is.a.thing.of.course'),
+                    2: $ref('oneoff')
+                }
+            }
+        });
+        var partDone = after(2, done);
+
+        model.get(['things', 0, 'tags', 0]).subscribe(noOp, done, partDone);
+        // path length differences:
+        // things[0].tags[0,1] -> requested: 4, optimized: 4
+        // things[1].tags[0,1] -> requested: 4, optimized: 10
+        // things[2].tags[0,1] -> requested: 4, optimized: 3
+        model.get(['things', { from: 0, to: 2 }, 'tags', { from: 0, to: 1 }]).subscribe(function(response) {
+            expect(onGet.getCall(1).args[1]).to.deep.equal([
+                ['oneoff', 'tags', { from: 0, to: 1 }],
+                ['things', 0, 'tags', '1'],
+                ['thang', 'that', 'really', 'is', 'a', 'thing', 'of', 'course', 'tags', { from: 0, to: 1 }]
+            ]);
+        }, done, partDone);
+    });
+});
+

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -5,7 +5,6 @@ var falcor = require('./../../browser');
 var expect = require('chai').expect;
 var sinon = require('sinon');
 var Router = require('falcor-router');
-var after = require('after');
 var strip = require('./../cleanData').stripDerefAndVersionKeys;
 var noOp = function() {};
 
@@ -14,18 +13,14 @@ describe('Get Integration Tests', function() {
 
     beforeEach(function(done) {
         app = express();
-        app.pathQueries = [];
-        app.use(function(req, res, next) {
-            app.pathQueries.push(JSON.parse(req.query.paths));
-            log('pathQuery', req.query.paths);
-            next();
-        });
         server = app.listen(1337, done);
         serverUrl = 'http://localhost:1337';
     });
 
     it('should be able to return null from a router. #535', function(done) {
-        var model = getModel();
+        var model = new falcor.Model({
+            source: new falcor.HttpDataSource(serverUrl + '/model.json')
+        });
         var onNext = sinon.spy();
         setRoutes([
             {
@@ -54,133 +49,10 @@ describe('Get Integration Tests', function() {
             subscribe(noOp, done, done);
     });
 
-    describe.only('Request deduping', function() {
-        it('should dedupe new requested paths with previous in-flight requests', function(done) {
-            var model = getModel();
-            setServerCache({
-                things: {
-                    0: 'thing: 0',
-                    1: 'thing: 1',
-                    2: 'thing: 2'
-                }
-            });
-            var partDone = after(2, done);
-
-            model.get(['things', { from: 0, to: 1 }]).subscribe(function(response) {
-                expect(app.pathQueries[0]).to.deep.equal([['things', { from: 0, to: 1 }]]);
-                expect(strip(response.json)).to.deep.equal({
-                    things: {
-                        0: 'thing: 0',
-                        1: 'thing: 1'
-                    }
-                });
-            }, done, partDone);
-            model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
-                expect(app.pathQueries[1]).to.deep.equal([['things', '2']]);
-                expect(strip(response.json)).to.deep.equal({
-                    things: {
-                        1: 'thing: 1',
-                        2: 'thing: 2'
-                    }
-                });
-            }, done, partDone);
-        });
-
-        it('should dedupe from both ends of overlapping ranges', function(done) {
-            var model = getModel();
-            setServerCache({
-                things: {
-                    0: 'thing: 0',
-                    1: 'thing: 1',
-                    2: 'thing: 2',
-                    3: 'thing: 3',
-                    4: 'thing: 4',
-                }
-            });
-            var partDone = after(2, done);
-
-            model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
-                expect(app.pathQueries[0]).to.deep.equal([['things', { from: 1, to: 2 }]]);
-            }, done, partDone);
-            model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
-                expect(app.pathQueries[1]).to.deep.equal([['things', [0, 3, 4]]]);
-            }, done, partDone);
-        });
-
-        it('should leave ranges unrolled if possible', function(done) {
-            var model = getModel();
-            setServerCache({
-                things: {
-                    0: 'thing: 0',
-                    1: 'thing: 1',
-                    2: 'thing: 2',
-                    3: 'thing: 3',
-                    4: 'thing: 4',
-                }
-            });
-            var partDone = after(2, done);
-
-            model.get(['things', { from: 0, to: 2 }]).subscribe(noOp, done, partDone);
-            model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
-                expect(app.pathQueries[1]).to.deep.equal([['things', { from: 3, to: 4 }]]);
-            }, done, partDone);
-        });
-
-        it('should work for properties after ranges', function(done) {
-            var model = getModel();
-            setServerCache({
-                things: {
-                    0: { name: 'thing: 0' },
-                    1: { name: 'thing: 1' },
-                    2: { name: 'thing: 2' },
-                }
-            });
-            var partDone = after(2, done);
-
-            model.get(['things', { from: 0, to: 1 }, 'name']).subscribe(noOp, done, partDone);
-            model.get(['things', { from: 1, to: 2 }, 'name']).subscribe(function() {
-                log('pathQueries', app.pathQueries);
-                expect(app.pathQueries[1]).to.deep.equal([['things', 2, 'name']]);
-            }, done, partDone);
-        });
-
-        it('should work for multiple ranges in path sets', function(done) {
-            var model = getModel();
-            setServerCache({
-                things: {
-                    0: { name: 'thing: 0', tags: { 0: 'thing: 0, tag: 0', 1: 'thing: 0, tag: 1' } },
-                    1: { name: 'thing: 1', tags: { 0: 'thing: 1, tag: 0', 1: 'thing: 1, tag: 1' } },
-                    2: { name: 'thing: 2', tags: { 0: 'thing: 2, tag: 0', 1: 'thing: 2, tag: 1' } },
-                }
-            });
-            var partDone = after(2, done);
-
-            partDone(); partDone();
-        });
-    });
-
     afterEach(function(done) {
         server.close(done);
     });
 
-    function getModel() {
-        return new falcor.Model({
-            source: new falcor.HttpDataSource(serverUrl + '/model.json')
-        });
-    }
-    function getThingsRoute() {
-        return {
-            route: 'things[{integers}]',
-            get: function(pathSet) {
-                return pathSet[1].map(function(id) {
-                    return {
-                        path: ['things', id],
-                        value: 'thing: ' + id
-                    }
-                });
-            }
-        };
-    }
     function setRoutes(routes) {
       app.use('/model.json', FalcorServer.dataSourceRoute(function() {
           return new Router(routes);
@@ -195,23 +67,3 @@ describe('Get Integration Tests', function() {
     }
 });
 
-function str(v, t) {
-  v = v instanceof Error ?
-    'Error: ' + v.message :
-    typeof v === 'object' && v !== null ? strip(v) : v;
-  try {
-    return JSON.stringify(v, null, t || 2);
-  } catch (e) {
-    return v;
-  }
-}
-function logger(ns) {
-  return function() {
-    console.log('>>>>', ns);
-    [].slice.call(arguments).map(str).forEach(v => {
-      console.log('  >>', v);
-    });
-    console.log('');
-  };
-}
-var log = logger('log');

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -2,49 +2,42 @@
 var express = require('express');
 var FalcorServer = require('falcor-express');
 var falcor = require('./../../browser');
-var Model = falcor.Model;
-var HttpDataSource = falcor.HttpDataSource;
 var expect = require('chai').expect;
 var sinon = require('sinon');
-var noOp = function() {};
 var Router = require('falcor-router');
+var after = require('after');
 var strip = require('./../cleanData').stripDerefAndVersionKeys;
+var noOp = function() {};
 
 describe('Get Integration Tests', function() {
-    var server;
+    var app, server, serverUrl;
+
     beforeEach(function(done) {
-        var app = express();
-
-        // Simple middleware to handle get/post
-        app.use('/model.json', FalcorServer.dataSourceRoute(function(req, res) {
-            return new Router([
-                {
-                    route: ['thing', 'prop'],
-                    get: function (path) {
-                        return {
-                            path: ['thing', 'prop'],
-                            value: null
-                        };
-                    }
-                }
-            ]);
-        }));
-
-        server = app.listen(1337, function(err) {
-            if (err) {
-                done(err);
-                return;
-            }
-            done();
+        app = express();
+        app.pathQueries = [];
+        app.use(function(req, res, next) {
+            app.pathQueries.push(JSON.parse(req.query.paths));
+            log('pathQuery', req.query.paths);
+            next();
         });
-
+        server = app.listen(1337, done);
+        serverUrl = 'http://localhost:1337';
     });
 
     it('should be able to return null from a router. #535', function(done) {
-        var model = new falcor.Model({
-            source: new falcor.HttpDataSource('http://localhost:1337/model.json')
-        });
+        var model = getModel();
         var onNext = sinon.spy();
+        setRoutes([
+            {
+                route: ['thing', 'prop'],
+                get: function (path) {
+                    return {
+                        path: ['thing', 'prop'],
+                        value: null
+                    };
+                }
+            }
+        ]);
 
         toObservable(model.
             get(['thing', 'prop'])).
@@ -61,7 +54,164 @@ describe('Get Integration Tests', function() {
             subscribe(noOp, done, done);
     });
 
-    afterEach(function() {
-        server.close();
+    describe.only('Request deduping', function() {
+        it('should dedupe new requested paths with previous in-flight requests', function(done) {
+            var model = getModel();
+            setServerCache({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2'
+                }
+            });
+            var partDone = after(2, done);
+
+            model.get(['things', { from: 0, to: 1 }]).subscribe(function(response) {
+                expect(app.pathQueries[0]).to.deep.equal([['things', { from: 0, to: 1 }]]);
+                expect(strip(response.json)).to.deep.equal({
+                    things: {
+                        0: 'thing: 0',
+                        1: 'thing: 1'
+                    }
+                });
+            }, done, partDone);
+            model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
+                expect(app.pathQueries[1]).to.deep.equal([['things', '2']]);
+                expect(strip(response.json)).to.deep.equal({
+                    things: {
+                        1: 'thing: 1',
+                        2: 'thing: 2'
+                    }
+                });
+            }, done, partDone);
+        });
+
+        it('should dedupe from both ends of overlapping ranges', function(done) {
+            var model = getModel();
+            setServerCache({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2',
+                    3: 'thing: 3',
+                    4: 'thing: 4',
+                }
+            });
+            var partDone = after(2, done);
+
+            model.get(['things', { from: 1, to: 2 }]).subscribe(function(response) {
+                expect(app.pathQueries[0]).to.deep.equal([['things', { from: 1, to: 2 }]]);
+            }, done, partDone);
+            model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
+                expect(app.pathQueries[1]).to.deep.equal([['things', [0, 3, 4]]]);
+            }, done, partDone);
+        });
+
+        it('should leave ranges unrolled if possible', function(done) {
+            var model = getModel();
+            setServerCache({
+                things: {
+                    0: 'thing: 0',
+                    1: 'thing: 1',
+                    2: 'thing: 2',
+                    3: 'thing: 3',
+                    4: 'thing: 4',
+                }
+            });
+            var partDone = after(2, done);
+
+            model.get(['things', { from: 0, to: 2 }]).subscribe(noOp, done, partDone);
+            model.get(['things', { from: 0, to: 4 }]).subscribe(function(response) {
+                expect(app.pathQueries[1]).to.deep.equal([['things', { from: 3, to: 4 }]]);
+            }, done, partDone);
+        });
+
+        it('should work for properties after ranges', function(done) {
+            var model = getModel();
+            setServerCache({
+                things: {
+                    0: { name: 'thing: 0' },
+                    1: { name: 'thing: 1' },
+                    2: { name: 'thing: 2' },
+                }
+            });
+            var partDone = after(2, done);
+
+            model.get(['things', { from: 0, to: 1 }, 'name']).subscribe(noOp, done, partDone);
+            model.get(['things', { from: 1, to: 2 }, 'name']).subscribe(function() {
+                log('pathQueries', app.pathQueries);
+                expect(app.pathQueries[1]).to.deep.equal([['things', 2, 'name']]);
+            }, done, partDone);
+        });
+
+        it('should work for multiple ranges in path sets', function(done) {
+            var model = getModel();
+            setServerCache({
+                things: {
+                    0: { name: 'thing: 0', tags: { 0: 'thing: 0, tag: 0', 1: 'thing: 0, tag: 1' } },
+                    1: { name: 'thing: 1', tags: { 0: 'thing: 1, tag: 0', 1: 'thing: 1, tag: 1' } },
+                    2: { name: 'thing: 2', tags: { 0: 'thing: 2, tag: 0', 1: 'thing: 2, tag: 1' } },
+                }
+            });
+            var partDone = after(2, done);
+
+            partDone(); partDone();
+        });
     });
+
+    afterEach(function(done) {
+        server.close(done);
+    });
+
+    function getModel() {
+        return new falcor.Model({
+            source: new falcor.HttpDataSource(serverUrl + '/model.json')
+        });
+    }
+    function getThingsRoute() {
+        return {
+            route: 'things[{integers}]',
+            get: function(pathSet) {
+                return pathSet[1].map(function(id) {
+                    return {
+                        path: ['things', id],
+                        value: 'thing: ' + id
+                    }
+                });
+            }
+        };
+    }
+    function setRoutes(routes) {
+      app.use('/model.json', FalcorServer.dataSourceRoute(function() {
+          return new Router(routes);
+      }));
+    }
+
+    function setServerCache(cache) {
+        var serverModel = new falcor.Model({ cache: cache });
+        app.use('/model.json', FalcorServer.dataSourceRoute(function() {
+            return serverModel.asDataSource();
+        }));
+    }
 });
+
+function str(v, t) {
+  v = v instanceof Error ?
+    'Error: ' + v.message :
+    typeof v === 'object' && v !== null ? strip(v) : v;
+  try {
+    return JSON.stringify(v, null, t || 2);
+  } catch (e) {
+    return v;
+  }
+}
+function logger(ns) {
+  return function() {
+    console.log('>>>>', ns);
+    [].slice.call(arguments).map(str).forEach(v => {
+      console.log('  >>', v);
+    });
+    console.log('');
+  };
+}
+var log = logger('log');

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -2,4 +2,5 @@ describe('Integration', function() {
     require('./call.spec');
     require('./express.spec');
     require('./get.spec');
+    require('./dedupe.spec');
 });

--- a/test/internal/request/GetRequest.add.spec.js
+++ b/test/internal/request/GetRequest.add.spec.js
@@ -197,6 +197,10 @@ describe('#add', function() {
         results[3]();
         zip();
     });
+
+
+    // Tests for partial deduping (https://github.com/Netflix/falcor/issues/779)
+    // are in test/integration/get.spec.js
 });
 function zipSpy(count, cb) {
     return sinon.spy(function() {

--- a/test/internal/request/GetRequest.add.spec.js
+++ b/test/internal/request/GetRequest.add.spec.js
@@ -57,7 +57,7 @@ describe('#add', function() {
         var disposable1 = request.batch([videos0], [videos0], zip);
         expect(request.sent, 'request should be sent').to.be.ok;
 
-        var results = request.add([videos0, videos1], [videos0, videos1], zip);
+        var results = request.add([videos0, videos1], [videos0, videos1], [0, 0], zip);
     });
 
     it('should send a request and dedupe another when dedupe is in second position.', function(done) {
@@ -102,7 +102,7 @@ describe('#add', function() {
         var disposable1 = request.batch([videos0], [videos0], zip);
         expect(request.sent, 'request should be sent').to.be.ok;
 
-        var results = request.add([videos1, videos0], [videos1, videos0], zip);
+        var results = request.add([videos1, videos0], [videos1, videos0], [0, 0], zip);
     });
 
 
@@ -147,7 +147,7 @@ describe('#add', function() {
         var disposable1 = request.batch([videos0], [videos0], zip);
         expect(request.sent, 'request should be sent').to.be.ok;
 
-        var results = request.add([videos0, videos1], [videos0, videos1], zip);
+        var results = request.add([videos0, videos1], [videos0, videos1], [0, 0], zip);
         zip();
     });
 
@@ -193,7 +193,7 @@ describe('#add', function() {
         var disposable1 = request.batch([videos0], [videos0], zip);
         expect(request.sent, 'request should be sent').to.be.ok;
 
-        var results = request.add([videos0, videos1], [videos0, videos1], zip);
+        var results = request.add([videos0, videos1], [videos0, videos1], [0, 0], zip);
         results[3]();
         zip();
     });

--- a/test/internal/request/RequestQueue.get.spec.js
+++ b/test/internal/request/RequestQueue.get.spec.js
@@ -24,7 +24,7 @@ describe('#get', function() {
         var model = new Model({source: source});
         var queue = new RequestQueue(model, scheduler);
         var callback = sinon.spy();
-        var disposable = queue.get([videos0], [videos0], callback);
+        var disposable = queue.get([videos0], [videos0], [0, 0], callback);
 
         expect(callback.calledOnce, 'callback should be called once.').to.be.ok;
         var onNext = sinon.spy();
@@ -76,8 +76,8 @@ describe('#get', function() {
                 }).
                 subscribe(noOp, done, done);
         });
-        var disposable = queue.get([videos0], [videos0], zip);
-        var disposable2 = queue.get([videos1], [videos1], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
+        var disposable2 = queue.get([videos1], [videos1], [0, 0], zip);
 
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(false);
@@ -112,11 +112,11 @@ describe('#get', function() {
                 }).
                 subscribe(noOp, done, done);
         });
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0], [videos0], zip);
+        var disposable2 = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
@@ -153,11 +153,11 @@ describe('#get', function() {
                 subscribe(noOp, done, done);
         }, 300);
 
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], zip);
+        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], [0, 0], zip);
         expect(queue._requests.length).to.equal(2);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[1].sent).to.equal(true);
@@ -194,11 +194,11 @@ describe('#get', function() {
                 }).
                 subscribe(noOp, done, done);
         }, 300);
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0], [videos0], zip);
+        var disposable2 = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
@@ -225,11 +225,11 @@ describe('#get', function() {
                 }).
                 subscribe(noOp, done, done);
         }, 300);
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0], [videos0], zip);
+        var disposable2 = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
@@ -265,11 +265,11 @@ describe('#get', function() {
                 }).
                 subscribe(noOp, done, done);
         }, 300);
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], zip);
+        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], [0, 0], zip);
         expect(queue._requests.length).to.equal(2);
         expect(queue._requests[1].sent).to.equal(true);
         expect(queue._requests[1].scheduled).to.equal(false);
@@ -296,11 +296,11 @@ describe('#get', function() {
                 subscribe(noOp, done, done);
         }, 300);
 
-        var disposable = queue.get([videos0], [videos0], zip);
+        var disposable = queue.get([videos0], [videos0], [0, 0], zip);
         expect(queue._requests.length).to.equal(1);
         expect(queue._requests[0].sent).to.equal(true);
         expect(queue._requests[0].scheduled).to.equal(false);
-        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], zip);
+        var disposable2 = queue.get([videos0, videos1], [videos0, videos1], [0, 0], zip);
         expect(queue._requests.length).to.equal(2);
         expect(queue._requests[1].sent).to.equal(true);
         expect(queue._requests[1].scheduled).to.equal(false);


### PR DESCRIPTION
update:
pull request is ready for review and merging! all edge cases covered.

update:
pull request is up for review now. all edge case bugs fixed. adding some tests now.

dedupes 2 major cases: paths followed via refs in cache, and paths with ranges in the end
pull request is still in progress, but still want to get opinion on the approach
work remaining: dedupe paths with more properties after the range, and not followed via refs in client cache (like `['videosById', { from: 0, to: 10 }, 'name' ]` where `videosById` is not in cache

fixes #779 