### PR TITLE
protect against model.invalidate(undefined) and model.invalidate([])

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -226,7 +226,7 @@ Model.prototype.invalidate = function invalidate() {
     args = [];
     while (++argsIdx < argsLen) {
         args[argsIdx] = pathSyntax.fromPath(arguments[argsIdx]);
-        if (!Array.isArray(args[argsIdx])) {
+        if (!Array.isArray(args[argsIdx]) || !args[argsIdx].length) {
             throw new Error("Invalid argument");
         }
     }

--- a/test/invalidate/index.js
+++ b/test/invalidate/index.js
@@ -35,4 +35,22 @@ module.exports = function() {
             }).
             subscribe(noOp, done, done);
     });
+
+    it('should throw for undefined paths', function() {
+        var model = new Model({ cache: { value: 1 } });
+        expect(() => model.invalidate(undefined)).to.throw();
+        expect(model.getCache()).to.deep.equal({ value: 1 });
+    });
+
+    it('should throw for empty paths', function() {
+        var model = new Model({ cache: { value: 1 } });
+        expect(() => model.invalidate([])).to.throw();
+        expect(model.getCache()).to.deep.equal({ value: 1 });
+    });
+
+    it('should do nothing for non-existing paths', function() {
+        var model = new Model({ cache: { value: 1 } });
+        model.invalidate('no.such.path');
+        expect(model.getCache()).to.deep.equal({ value: 1 });
+    });
 };


### PR DESCRIPTION
from blowing away the entire cache