### PR TITLE
Fixes #838 (Incorrect stack traces) and abstracts error type creation

### DIFF
--- a/lib/errors/BoundJSONGraphModelError.js
+++ b/lib/errors/BoundJSONGraphModelError.js
@@ -1,20 +1,15 @@
+var createErrorType = require("./createErrorType");
+
 /**
  * When a bound model attempts to retrieve JSONGraph it should throw an
  * error.
  *
  * @private
  */
-function BoundJSONGraphModelError() {
-    this.message = BoundJSONGraphModelError.message;
-    this.stack = (new Error()).stack;
-}
-
-// instanceof will be an error, but stack will be correct because its defined in the constructor.
-BoundJSONGraphModelError.prototype = new Error();
-BoundJSONGraphModelError.prototype.name = "BoundJSONGraphModelError";
-BoundJSONGraphModelError.message =
-    "It is not legal to use the JSON Graph " +
-    "format from a bound Model. JSON Graph format" +
-    " can only be used from a root model.";
+var BoundJSONGraphModelError = createErrorType(
+    "BoundJSONGraphModelError",
+    "It is not legal to use the JSON Graph format from a bound Model. JSON Graph format" +
+    " can only be used from a root model."
+);
 
 module.exports = BoundJSONGraphModelError;

--- a/lib/errors/InvalidDerefInputError.js
+++ b/lib/errors/InvalidDerefInputError.js
@@ -1,21 +1,14 @@
-var NAME = "InvalidDerefInputError";
-var MESSAGE = "Deref can only be used with a non-primitive object from get, set, or call.";
+var createErrorType = require("./createErrorType");
+
 /**
  * An invalid deref input is when deref is used with input that is not generated
  * from a get, set, or a call.
  *
- * @param {String} message
  * @private
  */
-function InvalidDerefInputError() {
-    this.message = MESSAGE;
-    this.stack = (new Error()).stack;
-}
-
-// instanceof will be an error, but stack will be correct because its defined in the constructor.
-InvalidDerefInputError.prototype = new Error();
-InvalidDerefInputError.prototype.name = NAME;
-InvalidDerefInputError.name = NAME;
-InvalidDerefInputError.message = MESSAGE;
+var InvalidDerefInputError = createErrorType(
+    "InvalidDerefInputError",
+    "Deref can only be used with a non-primitive object from get, set, or call."
+);
 
 module.exports = InvalidDerefInputError;

--- a/lib/errors/InvalidModelError.js
+++ b/lib/errors/InvalidModelError.js
@@ -1,22 +1,18 @@
-var NAME = "InvalidModelError";
-var MESSAGE = "The boundPath of the model is not valid since a value or error was found before the path end.";
+var createErrorType = require("./createErrorType");
+
 /**
  * An InvalidModelError can only happen when a user binds, whether sync
  * or async to shorted value.  See the unit tests for examples.
  *
- * @param {String} message
+ * @param {*} boundPath
+ * @param {*} shortedPath
+ *
  * @private
  */
-function InvalidModelError(boundPath, shortedPath) {
-    this.message = MESSAGE;
-    this.stack = (new Error()).stack;
-    this.boundPath = boundPath;
-    this.shortedPath = shortedPath;
-}
-
-// instanceof will be an error, but stack will be correct because its defined in the constructor.
-InvalidModelError.prototype = new Error();
-InvalidModelError.prototype.name = NAME;
-InvalidModelError.message = MESSAGE;
+var InvalidModelError = createErrorType(
+    "InvalidModelError",
+    "The boundPath of the model is not valid since a value or error was found before the path end.",
+    ["boundPath", "shortedPath"]
+);
 
 module.exports = InvalidModelError;

--- a/lib/errors/InvalidSourceError.js
+++ b/lib/errors/InvalidSourceError.js
@@ -1,23 +1,17 @@
-var NAME = "InvalidSourceError";
+var createErrorType = require("./createErrorType");
+
 /**
  * InvalidSourceError happens when a dataSource syncronously throws
  * an exception during a get/set/call operation.
  *
- * @param {Error} error - The error that was thrown.
+ * @param {Error} innerError - The error that was thrown.
+ *
  * @private
  */
-function InvalidSourceError(error) {
-    this.message = "An exception was thrown when making a request.";
-    this.stack = (new Error()).stack;
-    this.innerError = error;
-}
-
-// instanceof will be an error, but stack will be correct because its defined
-// in the constructor.
-InvalidSourceError.prototype = new Error();
-InvalidSourceError.prototype.name = NAME;
-InvalidSourceError.is = function(e) {
-    return e && e.name === NAME;
-};
+var InvalidSourceError = createErrorType(
+    "InvalidSourceError",
+    "An exception was thrown when making a request.",
+    ["innerError"]
+);
 
 module.exports = InvalidSourceError;

--- a/lib/errors/MaxRetryExceededError.js
+++ b/lib/errors/MaxRetryExceededError.js
@@ -1,22 +1,19 @@
-var NAME = "MaxRetryExceededError";
+var createErrorType = require("./createErrorType");
+
 /**
  * A request can only be retried up to a specified limit.  Once that
  * limit is exceeded, then an error will be thrown.
  *
+ * @param {*} missingOptimizedPaths
+ *
  * @private
  */
-function MaxRetryExceededError(missingOptimizedPaths) {
-    this.message = "The allowed number of retries have been exceeded.";
-    this.missingOptimizedPaths = missingOptimizedPaths || [];
-    this.stack = (new Error()).stack;
-}
-
-// instanceof will be an error, but stack will be correct because its defined
-// in the constructor.
-MaxRetryExceededError.prototype = new Error();
-MaxRetryExceededError.prototype.name = NAME;
-MaxRetryExceededError.is = function(e) {
-    return e && e.name === NAME;
-};
+var MaxRetryExceededError = createErrorType(
+    "MaxRetryExceededError",
+    "The allowed number of retries have been exceeded.",
+    function(instance, args) {
+        instance.missingOptimizedPaths = args[0] || [];
+    }
+);
 
 module.exports = MaxRetryExceededError;

--- a/lib/errors/NullInPathError.js
+++ b/lib/errors/NullInPathError.js
@@ -1,17 +1,13 @@
-var NAME = "NullInPathError";
-var MESSAGE = "`null` is not allowed in branch key positions.";
+var createErrorType = require("./createErrorType");
 
 /**
- * Does not allow null in path
+ * Does not allow null in path.
+ *
+ * @private
  */
-function NullInPathError() {
-    this.message = MESSAGE;
-    this.stack = (new Error()).stack;
-}
-
-// instanceof will be an error, but stack will be correct because its defined in the constructor.
-NullInPathError.prototype = new Error();
-NullInPathError.prototype.name = NAME;
-NullInPathError.message = MESSAGE;
+var NullInPathError = createErrorType(
+    "NullInPathError",
+    "`null` is not allowed in branch key positions."
+);
 
 module.exports = NullInPathError;

--- a/lib/errors/createErrorType.js
+++ b/lib/errors/createErrorType.js
@@ -1,0 +1,67 @@
+var util = require("util");
+
+/**
+ * Creates a new type of error.
+ *
+ * @param {string} name - The error type name
+ * @param {string} message - The error message
+ * @param {string[]|function} additionalKeys - Key names to set from arguments (or function to manually do so)
+ *
+ * @returns {function} Returns an Error class
+ *
+ * @private
+ */
+function createErrorType(name, message, additionalKeys) {
+
+    // Create the error type
+    var NewErrorType = function() {
+
+        // Call the "super" constructor
+        Error.call(this);
+
+        // Capture a proper stack trace
+        Error.captureStackTrace(this, this.constructor);
+
+        // Set the message of our error type
+        this.message = message;
+
+        // If the additionalKeys argument provided was a function, call it with the instance and arguments
+        // (this allows additional logic like applying defaults)
+        if (typeof additionalKeys === "function") {
+            additionalKeys(this, arguments);
+        }
+
+        // Otherwise, if arguments were passed and this error type allows additional keys to be set, set them
+        if (arguments.length > 0 && Array.isArray(additionalKeys)) {
+
+            // For each additional key allowed...
+            additionalKeys.forEach(function(key, i) {
+
+                // Check if that argument was passed, and if so, set that property of this instance
+                if (typeof arguments[i] !== "undefined") {
+                    this[key] = arguments[i];
+                }
+            });
+        }
+    };
+
+    // Inherit from the standard error type
+    util.inherits(NewErrorType, Error);
+
+    // Override the name of the function
+    var descriptor = Object.getOwnPropertyDescriptor(NewErrorType, "name");
+    descriptor.value = name;
+    Object.defineProperty(NewErrorType, "name", descriptor);
+
+    // Override the name on the prototype
+    NewErrorType.prototype.name = name;
+
+    // provide a .is() method for checking the error type
+    NewErrorType.is = function(e) {
+        return e && e.name === name;
+    };
+
+    return NewErrorType;
+}
+
+module.exports = createErrorType;

--- a/test/falcor/deref/deref.errors.spec.js
+++ b/test/falcor/deref/deref.errors.spec.js
@@ -35,7 +35,7 @@ describe('Error cases', function() {
                     get([0, 0, 'item', 'title'])).
                     doAction(onNext, function(err) {
                         expect(onNext.callCount).to.equal(1);
-                        expect(err.message).to.equals(InvalidModelError.message);
+                        expect(err.message).to.equals("The boundPath of the model is not valid since a value or error was found before the path end.");
                     }).
                     subscribe(
                         noOp,

--- a/test/get-core/deref.spec.js
+++ b/test/get-core/deref.spec.js
@@ -81,7 +81,7 @@ describe('Deref', function() {
 
         var res = model._getPathValuesAsJSONG(model, [['summary']], [{}]);
         expect(res.criticalError.name).to.equals(BoundJSONGraphModelError.name);
-        expect(res.criticalError.message).to.equals(BoundJSONGraphModelError.message);
+        expect(res.criticalError.message).to.equals("It is not legal to use the JSON Graph format from a bound Model. JSON Graph format can only be used from a root model.");
     });
 
     it('should ensure that correct parents are produced for non-paths.', function(done) {


### PR DESCRIPTION
This change should provide a proper stack trace when errors are thrown (#838).

There was also some inconsistent, duplicated code between the error types. I abstracted it into a single function to create error types so it can be documented, tested, and maintained consistently. (It is not currently directly tested, but has full coverage through use cases).