### PR TITLE
Fix max retries on clone

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -90,7 +90,7 @@ function Model(o) {
     if (typeof options.maxRetries === "number") {
         this._maxRetries = options.maxRetries;
     } else {
-        this._maxRetries = options.maxRetries || Model.prototype._maxRetries;
+        this._maxRetries = options._maxRetries || Model.prototype._maxRetries;
     }
 
     if (typeof options.collectRatio === "number") {

--- a/test/Model.spec.js
+++ b/test/Model.spec.js
@@ -246,6 +246,17 @@ describe("Model", function() {
         done();
     });
 
+    // https://github.com/Netflix/falcor/issues/915
+    it('maxRetries option is carried over to cloned Model instance', function(done) {
+        var model = new Model({
+            maxRetries: 10
+        });
+        expect(model._maxRetries).to.equal(10);
+        var batchingModel = model.batch(100);
+        expect(batchingModel._maxRetries).to.equal(10);
+        done();
+    });
+
     describe('JSON-Graph Specification', function() {
         require('./get-core');
 


### PR DESCRIPTION
https://github.com/Netflix/falcor/issues/915

No clue if you guys take pull requests but this appears to fix the issue above.

For ease of reading at a glance I will reiterate what this is fixing. batch calls this._clone, _clone instantiates Model with `this`, the instance of the model does not have a property maxRetries but rather _maxRetries, therefore maxRetries gets reset to the default if you do the following

`new falcor.Model({maxRetries: 10, ... }).batch(...)`

Also I can write a test for this if you'd like