### PR TITLE
Response stuffing

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -113,6 +113,8 @@ function Model(o) {
         this._treatErrorsAsValues = options._treatErrorsAsValues;
     }
 
+    this._useServerPaths = options._useServerPaths || false;
+
     this._allowFromWhenceYouCame = options.allowFromWhenceYouCame ||
         options._allowFromWhenceYouCame || false;
 

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -105,7 +105,7 @@ GetRequestV2.prototype = {
                             currentCacheVersion.setVersion(currentVersion);
                             var mergeContext = {hasInvalidatedResult : false};
 
-                            var pathsErr = model._useServerPaths && data.paths === undefined ?
+                            var pathsErr = model._useServerPaths && data && data.paths === undefined ?
                                 new Error("Server responses must include a 'paths' field when Model._useServerPaths === true") : undefined;
 
                             if (!pathsErr) {

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -104,14 +104,21 @@ GetRequestV2.prototype = {
                             var currentVersion = incrementVersion.getCurrentVersion();
                             currentCacheVersion.setVersion(currentVersion);
                             var mergeContext = {hasInvalidatedResult : false};
-                            self._merge(rPaths, err, data, mergeContext);
+
+                            var pathsErr = model._useServerPaths && data.paths === undefined ?
+                                new Error("Server responses must include a 'paths' field when Model._useServerPaths === true") : undefined;
+
+                            if (!pathsErr) {
+                                self._merge(rPaths, err, data, mergeContext);
+                            }
+
                             // Call the callbacks.  The first one inserts all
                             // the data so that the rest do not have consider
                             // if their data is present or not.
                             for (i = 0, len = callbacks.length; i < len; ++i) {
                                 fn = callbacks[i];
                                 if (fn) {
-                                    fn(err, data, mergeContext.hasInvalidatedResult);
+                                    fn(pathsErr || err, data, mergeContext.hasInvalidatedResult);
                                 }
                             }
                             currentCacheVersion.setVersion(null);
@@ -190,7 +197,7 @@ GetRequestV2.prototype = {
         model._path = emptyArray;
 
         // flatten all the requested paths, adds them to the
-        var nextPaths = flattenRequestedPaths(requested);
+        var nextPaths = model._useServerPaths ? data.paths : flattenRequestedPaths(requested);
 
         // Insert errors in every requested position.
         if (err && model._treatDataSourceErrorsAsJSONGraphErrors) {

--- a/lib/support/mergeJSONGraphNode.js
+++ b/lib/support/mergeJSONGraphNode.js
@@ -192,7 +192,7 @@ module.exports = function mergeJSONGraphNode(
         }
     }
     else if (node == null) {
-        node = insertNode(message, parent, key, undefined, optimizedPath);
+        node = insertNode({}, parent, key, undefined, optimizedPath);
     }
 
     return node;

--- a/test/falcor/get/get.dataSource-only.spec.js
+++ b/test/falcor/get/get.dataSource-only.spec.js
@@ -275,6 +275,89 @@ describe('DataSource Only', function() {
         }, 200);
     });
 
+    it('should ignore response-stuffed paths.', function(done) {
+        var onGet = sinon.spy();
+        var source = new LocalDataSource(cacheGenerator(0, 2), {
+            onGet: onGet,
+            wait: 100
+        });
+        var model = new Model({source: source}).batch(1);
+        var onNext = sinon.spy();
+        var disposable1 = toObservable(model.
+            get(['videos', 0, 'title'])).
+            doAction(onNext, noOp, function() {
+                throw new Error('Should not of completed.  It was disposed.');
+            }).
+            subscribe(noOp, done);
+
+        toObservable(model.
+            get(['videos', 1, 'title'])).
+            subscribe(noOp, done);
+
+        setTimeout(function() {
+            disposable1.dispose();
+        }, 30);
+
+        setTimeout(function() {
+            try {
+                expect(model._root.cache.videos[0]).to.be.undefined;
+            } catch(e) {
+                return done(e);
+            }
+            return done();
+        }, 200);
+    });
+
+    it('should honor response-stuffed paths with _useServerPaths == true.', function(done) {
+        var onGet = sinon.spy();
+        var source = new LocalDataSource(cacheGenerator(0, 2), {
+            onGet: onGet,
+            wait: 100,
+            onResults: function(data) {
+                data.paths = [
+                    ['videos', 0, 'title'],
+                    ['videos', 1, 'title']
+                ];
+            }
+        });
+        var model = new Model({source: source, _useServerPaths: true}).batch(1);
+        var onNext = sinon.spy();
+        var disposable1 = toObservable(model.
+            get(['videos', 0, 'title'])).
+            doAction(onNext, noOp, function() {
+                throw new Error('Should not of completed.  It was disposed.');
+            }).
+            subscribe(noOp, done);
+
+        toObservable(model.
+            get(['videos', 1, 'title'])).
+            subscribe(noOp, done);
+
+        setTimeout(function() {
+            disposable1.dispose();
+        }, 30);
+
+        setTimeout(function() {
+            try {
+                expect(model._root.cache.videos[0].$_absolutePath).to.deep.equal(['videos', 0]);
+            } catch(e) {
+                return done(e);
+            }
+            return done();
+        }, 200);
+    });
+
+    it('should throw when server paths are missing and _useServerPaths == true.', function(done) {
+        var source = new LocalDataSource(cacheGenerator(0, 2));
+        var model = new Model({source: source, _useServerPaths: true}).batch(1);
+        toObservable(model.
+            get(['videos', 0, 'title'])).
+            subscribe(noOp, function(err) {
+                expect(err.message).to.equal("Server responses must include a 'paths' field when Model._useServerPaths === true");
+                done();
+            });
+    });
+
     it('should be able to dispose one of two get requests..', function(done) {
         var onGet = sinon.spy();
         var source = new LocalDataSource(cacheGenerator(0, 2), {

--- a/test/set/edge-cases.spec.js
+++ b/test/set/edge-cases.spec.js
@@ -42,7 +42,7 @@ describe("Special Cases", function() {
         var edgeCaseCache = {
             jsonGraph: {
                 user: {
-                    name: "Jim",
+                    name: {$type: $atom, value: "Jim"},
                     location: {$type: "error", value: "Something broke!"},
                     age: {$type: $atom}
                 }


### PR DESCRIPTION
This PR accomplishes two things:

It fixes a bug where whole branches were merged from jsonGraph responses, leading to nodes to be merged without also receiving their metadata such as $_absolutePath.

Adds a (for now) private model flag, _useServerPaths which can enable folks to opt into response stuffing. I opted for a private flag for now as I see this as a pretty major foot gun.