### PR TITLE
Update homepage-getting-started.md to match README

### DIFF
--- a/_includes/homepage-getting-started.md
+++ b/_includes/homepage-getting-started.md
@@ -60,6 +60,9 @@ app.use('/model.json', falcorExpress.dataSourceRoute(function (req, res) {
   ]);
 }));
 
+// serve static files from current directory
+app.use(express.static(__dirname + '/'));
+
 var server = app.listen(3000);
 ~~~
 


### PR DESCRIPTION
Adds a line in `index.js` for serving static files from current directory so reader can visit `localhost:3000/index.html` in the next step.

Assuming this is the right file to update code sample at https://netflix.github.io/falcor/