### PR TITLE
Properly handle outerResults as an optional argument

### DIFF
--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -132,6 +132,7 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
           }
         }
     }
-
-    outerResults.hasValues = hasValues;
+    if (outerResults) {
+        outerResults.hasValues = hasValues;
+    }
 };


### PR DESCRIPTION
Hey, sorry for the urgent flag, but this is an issue that is keeping my team from using Falcor v2 and it's a very simple fix so would be great to have it merged in and published quickly if possible.

We haven't completely isolated a fully reproducible case, but it has something to do with refs being followed, and we've been getting the following error message:
![screenshot from 2018-04-23 10-34-38](https://user-images.githubusercontent.com/18149242/39110405-14d2cf90-46e2-11e8-8864-42e2cdfb53ed.png)

The below small fix works though (tried changing it directly in my node_modules), and also seems it should be there as in `followReference` you explicitly pass `null` as the `outerResults` argument.

Hope this can be resolved quickly, thanks!