### PR TITLE
Issue #915 reintroduced in v2 of Falcor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-    - "4"
     - "6"
+    - "8"
 
 branches:
     only:

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -90,7 +90,7 @@ function Model(o) {
     if (typeof options.maxRetries === "number") {
         this._maxRetries = options.maxRetries;
     } else {
-        this._maxRetries = options.maxRetries || Model.prototype._maxRetries;
+        this._maxRetries = options._maxRetries || Model.prototype._maxRetries;
     }
 
     if (typeof options.collectRatio === "number") {

--- a/test/Model.spec.js
+++ b/test/Model.spec.js
@@ -246,6 +246,17 @@ describe("Model", function() {
         done();
     });
 
+    // https://github.com/Netflix/falcor/issues/915
+    it('maxRetries option is carried over to cloned Model instance', function(done) {
+        var model = new Model({
+            maxRetries: 10
+        });
+        expect(model._maxRetries).to.equal(10);
+        var batchingModel = model.batch(100);
+        expect(batchingModel._maxRetries).to.equal(10);
+        done();
+    });
+
     describe('JSON-Graph Specification', function() {
         require('./get-core');
 


### PR DESCRIPTION
Due to incorrect reference to internal property of _maxRetries when
cloning a Falcor model instance, which occurs internally when enabling
batching, maxRetries always gets reset when enabling batching.

Originally fixed in PR #917