### PR TITLE
Fix model get dispose

### DIFF
--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -124,13 +124,18 @@ GetRequestV2.prototype = {
                             currentCacheVersion.setVersion(null);
                         }
                     });
-            });
+                    self._disposable = flushedDisposable;
+                });
 
-            // There is a race condition here. If the scheduler is sync then it
-            // exposes a condition where the flush request cannot be disposed.
-            // To correct this issue, if there is no flushedDisposable, then the
-            // scheduler is async and should use scheduler disposable, else use
-            // the flushedDisposable.
+            // If the scheduler is sync then `flushedDisposable` will be
+            // defined, and we want to use it, because that's what aborts an
+            // in-flight XHR request, for example.
+            // But if the scheduler is async, then `flushedDisposable` won't be
+            // defined yet, and so we must use the scheduler's disposable until
+            // `flushedDisposable` is defined. Since we want to still use
+            // `flushedDisposable` once it is defined (to be able to abort in-
+            // flight XHR requests), hence the reassignment of `_disposable`
+            // above.
             self._disposable = flushedDisposable || scheduleDisposable;
         }
 

--- a/lib/request/GetRequestV2.js
+++ b/lib/request/GetRequestV2.js
@@ -67,65 +67,64 @@ GetRequestV2.prototype = {
 
             var flushedDisposable;
             var scheduleDisposable = self._scheduler.schedule(function() {
-                flushedDisposable =
-                    flushGetRequest(self, oPaths, function(err, data) {
-                        var i, fn, len;
-                        var model = self.requestQueue.model;
-                        self.requestQueue.removeRequest(self);
-                        self._disposed = true;
+                flushedDisposable = flushGetRequest(self, oPaths, function(err, data) {
+                    var i, fn, len;
+                    var model = self.requestQueue.model;
+                    self.requestQueue.removeRequest(self);
+                    self._disposed = true;
 
-                        if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
-                            for (i = 0, len = callbacks.length; i < len; ++i) {
-                                fn = callbacks[i];
-                                if (fn) {
-                                    fn(err);
-                                }
+                    if (model._treatDataSourceErrorsAsJSONGraphErrors ? err instanceof InvalidSourceError : !!err) {
+                        for (i = 0, len = callbacks.length; i < len; ++i) {
+                            fn = callbacks[i];
+                            if (fn) {
+                                fn(err);
                             }
-                            return;
+                        }
+                        return;
+                    }
+
+                    // If there is at least one callback remaining, then
+                    // callback the callbacks.
+                    if (self._count) {
+                        // currentVersion will get added to each inserted
+                        // node as node.$_version inside of self._merge.
+                        //
+                        // atom values just downloaded with $expires: 0
+                        // (now-expired) will get assigned $_version equal
+                        // to currentVersion, and checkCacheAndReport will
+                        // later consider those nodes to not have expired
+                        // for the duration of current event loop tick
+                        //
+                        // we unset currentCacheVersion after all callbacks
+                        // have been called, to ensure that only these
+                        // particular callbacks and any synchronous model.get
+                        // callbacks inside of these, get the now-expired
+                        // values
+                        var currentVersion = incrementVersion.getCurrentVersion();
+                        currentCacheVersion.setVersion(currentVersion);
+                        var mergeContext = {hasInvalidatedResult : false};
+
+                        var pathsErr = model._useServerPaths && data && data.paths === undefined ?
+                            new Error("Server responses must include a 'paths' field when Model._useServerPaths === true") : undefined;
+
+                        if (!pathsErr) {
+                            self._merge(rPaths, err, data, mergeContext);
                         }
 
-                        // If there is at least one callback remaining, then
-                        // callback the callbacks.
-                        if (self._count) {
-                            // currentVersion will get added to each inserted
-                            // node as node.$_version inside of self._merge.
-                            //
-                            // atom values just downloaded with $expires: 0
-                            // (now-expired) will get assigned $_version equal
-                            // to currentVersion, and checkCacheAndReport will
-                            // later consider those nodes to not have expired
-                            // for the duration of current event loop tick
-                            //
-                            // we unset currentCacheVersion after all callbacks
-                            // have been called, to ensure that only these
-                            // particular callbacks and any synchronous model.get
-                            // callbacks inside of these, get the now-expired
-                            // values
-                            var currentVersion = incrementVersion.getCurrentVersion();
-                            currentCacheVersion.setVersion(currentVersion);
-                            var mergeContext = {hasInvalidatedResult : false};
-
-                            var pathsErr = model._useServerPaths && data && data.paths === undefined ?
-                                new Error("Server responses must include a 'paths' field when Model._useServerPaths === true") : undefined;
-
-                            if (!pathsErr) {
-                                self._merge(rPaths, err, data, mergeContext);
+                        // Call the callbacks.  The first one inserts all
+                        // the data so that the rest do not have consider
+                        // if their data is present or not.
+                        for (i = 0, len = callbacks.length; i < len; ++i) {
+                            fn = callbacks[i];
+                            if (fn) {
+                                fn(pathsErr || err, data, mergeContext.hasInvalidatedResult);
                             }
-
-                            // Call the callbacks.  The first one inserts all
-                            // the data so that the rest do not have consider
-                            // if their data is present or not.
-                            for (i = 0, len = callbacks.length; i < len; ++i) {
-                                fn = callbacks[i];
-                                if (fn) {
-                                    fn(pathsErr || err, data, mergeContext.hasInvalidatedResult);
-                                }
-                            }
-                            currentCacheVersion.setVersion(null);
                         }
-                    });
-                    self._disposable = flushedDisposable;
+                        currentCacheVersion.setVersion(null);
+                    }
                 });
+                self._disposable = flushedDisposable;
+            });
 
             // If the scheduler is sync then `flushedDisposable` will be
             // defined, and we want to use it, because that's what aborts an

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "toObservable": false
+  },
+  "rules": {
+    "space-before-function-paren": [ 0 ],
+    "quotes": [ 0 ],
+    "no-unused-expressions": [ 0 ]
+  }
+}

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -10,19 +10,19 @@ var MaxRetryExceededError = require('../../lib/errors/MaxRetryExceededError');
 var noOp = function() {};
 
 describe('Get Integration Tests', function() {
-    var app, server, serverUrl;
+    var app, server, serverUrl, model, onNext;
 
     beforeEach(function(done) {
         app = express();
         server = app.listen(1337, done);
         serverUrl = 'http://localhost:1337';
+        model = new falcor.Model({
+            source: new falcor.HttpDataSource(serverUrl + '/model.json')
+        });
+        onNext = sinon.spy();
     });
 
     it('should be able to return null from a router. #535', function(done) {
-        var model = new falcor.Model({
-            source: new falcor.HttpDataSource(serverUrl + '/model.json')
-        });
-        var onNext = sinon.spy();
         setRoutes([
             {
                 route: ['thing', 'prop'],
@@ -52,10 +52,6 @@ describe('Get Integration Tests', function() {
 
     describe('expiry', function() {
         it('$expires = 0 should expire immediately after current tick of event loop', function(done) {
-            var model = new falcor.Model({
-                source: new falcor.HttpDataSource(serverUrl + '/model.json')
-            });
-            var onNext = sinon.spy();
             setRoutes([{
                 route: ['path'],
                 get: function() {
@@ -92,10 +88,6 @@ describe('Get Integration Tests', function() {
         });
 
         it('$expires = 1 should never expire (unless kicked out by LRU cache)', function(done) {
-            var model = new falcor.Model({
-                source: new falcor.HttpDataSource(serverUrl + '/model.json')
-            });
-            var onNext = sinon.spy();
             setRoutes([{
                 route: ['path'],
                 get: function() {
@@ -135,10 +127,6 @@ describe('Get Integration Tests', function() {
         });
 
         it('$expires = -<timestamp> should expire in relative future', function(done) {
-            var model = new falcor.Model({
-                source: new falcor.HttpDataSource(serverUrl + '/model.json')
-            });
-            var onNext = sinon.spy();
             setRoutes([{
                 route: ['path'],
                 get: function() {
@@ -176,10 +164,6 @@ describe('Get Integration Tests', function() {
         });
 
         it('$expires = <timestamp> should expire at absolute time', function(done) {
-            var model = new falcor.Model({
-                source: new falcor.HttpDataSource(serverUrl + '/model.json')
-            });
-            var onNext = sinon.spy();
             setRoutes([{
                 route: ['path'],
                 get: function() {
@@ -217,10 +201,6 @@ describe('Get Integration Tests', function() {
         });
 
         it('$expires = <past timestamp> has already expired, causing retries', function(done) {
-            var model = new falcor.Model({
-                source: new falcor.HttpDataSource(serverUrl + '/model.json')
-            });
-            var onNext = sinon.spy();
             setRoutes([{
                 route: ['path'],
                 get: function() {


### PR DESCRIPTION
Currently, dispose a model.get().subscribe() does not abort the inner XHR calls made by that model.get
This PR fixes that by threading the model get dispose through correctly to the get request's dispose.

This is the relevant commit that makes the fix: https://github.com/Netflix/falcor/commit/4c9ca5d8
Tests coming shortly.