### PR TITLE
fix minor syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ app.use('/model.json', falcorExpress.dataSourceRoute(function (req, res) {
       // match a request for the key 'greeting'
       route: 'greeting',
       // respond with a PathValue with the value of 'Hello World.'
-      get: () => ({path: ['greeting'], value: 'Hello World'});
+      get: () => ({path: ['greeting'], value: 'Hello World'})
     }
   ]);
 }));


### PR DESCRIPTION
the example code had a syntax error due to an errant semicolon inside of an object literal