### PR TITLE
fix: typescript transpilation / assertion error in 2.9.x

### DIFF
--- a/lib/response/get/GetResponse.js
+++ b/lib/response/get/GetResponse.js
@@ -14,10 +14,8 @@ var getSize = require("./../../support/getSize");
  * @augments ModelResponse
  * @private
  */
-var GetResponse = module.exports = function GetResponse(model, paths,
-                                                        isJSONGraph,
-                                                        isProgressive,
-                                                        forceCollect) {
+var GetResponse = function GetResponse(model, paths, isJSONGraph,
+                                       isProgressive, forceCollect) {
     this.model = model;
     this.currentRemainingPaths = paths;
     this.isJSONGraph = isJSONGraph || false;
@@ -79,3 +77,5 @@ GetResponse.prototype._subscribe = function _subscribe(observer) {
     return getRequestCycle(this, model, results,
                            observer, errors, 1);
 };
+
+module.exports = GetResponse;

--- a/lib/response/set/SetResponse.js
+++ b/lib/response/set/SetResponse.js
@@ -22,9 +22,8 @@ var setRequestCycle = require("./setRequestCycle");
  * @augments ModelResponse
  * @private
  */
-var SetResponse = module.exports = function SetResponse(model, args,
-                                                        isJSONGraph,
-                                                        isProgressive) {
+var SetResponse = function SetResponse(model, args, isJSONGraph,
+                                       isProgressive) {
 
     // The response properties.
     this._model = model;
@@ -106,3 +105,5 @@ SetResponse.prototype.progressively = function progressively() {
     return new SetResponse(this._model, this._initialArgs,
                            this._isJSONGraph, true);
 };
+
+module.exports = SetResponse;


### PR DESCRIPTION
**Case in Point**
Using `falcor@^2.0.6` with Angular 6 with Typescript 2.9.2 when generating source maps fails with this message from Typescript transpilation: `Error: Debug Failure. False expression.`

**Issues fixed**
Because of the `a = b = c` structure used below (in `GetResponse.js` and `SetResponse.js`):
`var GetResponse = module.exports = function GetResponse(model, paths ...`
This triggers the following github issue: https://github.com/Microsoft/TypeScript/issues/24963.
   
As we are using Angular 6, it is undesirable to change Typescript versions, so i'm fixing the problem at the source.  There are other areas where this pattern exists in the **falcor** codebase, but this is the minimal change to solve our immediate issue.  Happy to update the other files if it's a requirement.

I have tested our Angular project with this branch and it works successfully.