### PR TITLE
Empty keyset bug

### DIFF
--- a/lib/get/onValue.js
+++ b/lib/get/onValue.js
@@ -127,7 +127,9 @@ module.exports = function onValue(model, node, seed, depth, outerResults,
         if (valueNode !== undefined) {
           if (k != null) {
               hasValues = true;
-              curr[k] = valueNode;
+              if (!curr[k]) {
+                curr[k] = valueNode;
+              }
           } else {
               // We are protected from reaching here when depth is 1 and prev is
               // undefined by the InvalidModelError and NullInPathError checks.

--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -42,8 +42,8 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
         onValueType(model, curr, path, depth, seed, outerResults, branchInfo,
             requestedPath, optimizedPath, optimizedLength,
             isJSONG, fromReference);
-    return;
-}
+        return;
+    }
 
     var allowFromWhenceYouCame = model._allowFromWhenceYouCame;
     var optimizedLengthPlus1 = optimizedLength + 1;

--- a/test/falcor/get/get.cache-only.spec.js
+++ b/test/falcor/get/get.cache-only.spec.js
@@ -1,64 +1,59 @@
-var falcor = require("./../../../lib");
-var Model = falcor.Model;
-var Rx = require('rx');
-var clean = require('./../../cleanData').clean;
-var cacheGenerator = require('./../../CacheGenerator');
-var noOp = function() {};
-var Observable = Rx.Observable;
-var clean = require('./../../cleanData').stripDerefAndVersionKeys;
-var toObservable = require('../../toObs');
+const falcor = require("./../../../lib");
+const Model = falcor.Model;
+const cacheGenerator = require("./../../CacheGenerator");
+const noOp = function() {};
+const clean = require("./../../cleanData").stripDerefAndVersionKeys;
+const toObservable = require("../../toObs");
 
-describe('Cache Only', function() {
-    describe('PathMap', function() {
-        it('should get a value from falcor.', function(done) {
-            var model = new Model({
-                cache: cacheGenerator(0, 1)
+describe("Cache Only", () => {
+    describe("PathMap", () => {
+        it("should get a value from falcor.", done => {
+            const model = new Model({
+                cache: cacheGenerator(0, 1),
             });
-            var onNext = jest.fn();
-            toObservable(model.
-                get(['videos', 0, 'title'])).
-                doAction(onNext, noOp, function() {
+            const onNext = jest.fn();
+            toObservable(model.get(["videos", 0, "title"]))
+                .doAction(onNext, noOp, () => {
                     expect(onNext).toHaveBeenCalledTimes(1);
                     expect(clean(onNext.mock.calls[0][0])).toEqual({
                         json: {
                             videos: {
                                 0: {
-                                    title: 'Video 0'
-                                }
-                            }
-                        }
+                                    title: "Video 0",
+                                },
+                            },
+                        },
                     });
-                }).
-                subscribe(noOp, done, done);
+                })
+                .subscribe(noOp, done, done);
         });
-        it('should onNext, then complete on empty paths.', function(done) {
-            var model = new Model({
-                cache: cacheGenerator(0, 1)
+        it("should onNext, then complete on empty paths.", done => {
+            const model = new Model({
+                cache: cacheGenerator(0, 1),
             });
-            var onNext = jest.fn();
-            toObservable(model.
-                get(['videos', [], 'title'])).
-                doAction(onNext, noOp, function() {
+            const onNext = jest.fn();
+            toObservable(model.get(["videos", [], "title"]))
+                .doAction(onNext, noOp, () => {
                     expect(clean(onNext.mock.calls[0][0])).toEqual({
                         json: {
-                            videos: {}
-                        }
+                            videos: {},
+                        },
                     });
                     expect(onNext).toHaveBeenCalledTimes(1);
-                }).
-                subscribe(noOp, done, done);
+                })
+                .subscribe(noOp, done, done);
         });
 
-        it('should use a promise to get request.', function(done) {
-            var model = new Model({
-                cache: cacheGenerator(0, 1)
+        it("should use a promise to get request.", done => {
+            const model = new Model({
+                cache: cacheGenerator(0, 1),
             });
-            var onNext = jest.fn();
-            var onError = jest.fn();
-            model.
-                get(['videos', 0, 'title']).
-                then(onNext, onError).
-                then(function() {
+            const onNext = jest.fn();
+            const onError = jest.fn();
+            model
+                .get(["videos", 0, "title"])
+                .then(onNext, onError)
+                .then(() => {
                     if (onError.mock.calls[0]) {
                         throw onError.mock.calls[0][0];
                     }
@@ -68,34 +63,36 @@ describe('Cache Only', function() {
                         json: {
                             videos: {
                                 0: {
-                                    title: 'Video 0'
-                                }
-                            }
-                        }
+                                    title: "Video 0",
+                                },
+                            },
+                        },
                     });
-                }).
-                then(function() { done(); }, done);
+                })
+                .then(() => {
+                    done();
+                }, done);
         });
     });
 
-    describe('_toJSONG', function() {
-        it('should get a value from falcor.', function(done) {
-            var model = new Model({
-                cache: cacheGenerator(0, 30)
+    describe("_toJSONG", () => {
+        it("should get a value from falcor.", done => {
+            const model = new Model({
+                cache: cacheGenerator(0, 30),
             });
-            var onNext = jest.fn();
-            toObservable(model.
-                get(['lolomo', 0, 0, 'item', 'title']).
-                _toJSONG()).
-                doAction(onNext, noOp, function() {
-                    var out = clean(onNext.mock.calls[0][0]);
-                    var expected = clean({
+            const onNext = jest.fn();
+            toObservable(
+                model.get(["lolomo", 0, 0, "item", "title"])._toJSONG()
+            )
+                .doAction(onNext, noOp, () => {
+                    const out = clean(onNext.mock.calls[0][0]);
+                    const expected = clean({
                         jsonGraph: cacheGenerator(0, 1),
-                        paths: [['lolomo', 0, 0, 'item', 'title']]
+                        paths: [["lolomo", 0, 0, "item", "title"]],
                     });
                     expect(out).toEqual(expected);
-                }).
-                subscribe(noOp, done, done);
+                })
+                .subscribe(noOp, done, done);
         });
     });
 });

--- a/test/falcor/get/get.cache-only.spec.js
+++ b/test/falcor/get/get.cache-only.spec.js
@@ -44,6 +44,23 @@ describe("Cache Only", () => {
                 .subscribe(noOp, done, done);
         });
 
+        it("should not void data on empty paths.", done => {
+            const model = new Model({
+                cache: cacheGenerator(0, 1),
+            });
+            const onNext = jest.fn();
+            toObservable(model.get(["videos", 0, "title"], ["videos", [], "title"]))
+                .doAction(onNext, noOp, () => {
+                    expect(clean(onNext.mock.calls[0][0])).toEqual({
+                        json: {
+                            videos: { 0: { title: "Video 0" } },
+                        },
+                    });
+                    expect(onNext).toHaveBeenCalledTimes(1);
+                })
+                .subscribe(noOp, done, done);
+        });
+
         it("should use a promise to get request.", done => {
             const model = new Model({
                 cache: cacheGenerator(0, 1),


### PR DESCRIPTION
When calling `Model.get()` with overlapping path sets where a subsequent path set contains an empty key set, some values in the result are lost. This has been fixed by not overwriting an existing result node.