### PR TITLE
Skip nulls in path instead of throwing

### DIFF
--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -4,7 +4,6 @@ var onValue = require("./onValue");
 var isExpired = require("./util/isExpired");
 var iterateKeySet = require("falcor-path-utils").iterateKeySet;
 var $ref = require("./../types/ref");
-var NullInPathError = require("./../errors/NullInPathError");
 var promote = require("./../lru/promote");
 
 module.exports = function walkPath(model, root, curr, path, depth, seed,
@@ -37,14 +36,6 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
         key = iterateKeySet(keySet, iteratorNote);
     }
 
-    // Avoid iterating on empty keysets
-    if (isKeySet && iteratorNote.done) {
-        onValueType(model, curr, path, depth, seed, outerResults, branchInfo,
-            requestedPath, optimizedPath, optimizedLength,
-            isJSONG, fromReference);
-        return;
-    }
-
     var allowFromWhenceYouCame = model._allowFromWhenceYouCame;
     var optimizedLengthPlus1 = optimizedLength + 1;
     var nextDepth = depth + 1;
@@ -53,7 +44,16 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
     // loop over every key in the key set
     do {
         if (key == null) {
-            throw new NullInPathError();
+            // Skip null/undefined/empty keysets in path and do not descend, but capture the partial path in the result
+            onValueType(model, curr, path, depth, seed, outerResults, branchInfo,
+                requestedPath, optimizedPath, optimizedLength,
+                isJSONG, fromReference);
+
+            if (iteratorNote && !iteratorNote.done) {
+                key = iterateKeySet(keySet, iteratorNote);
+            }
+
+            continue;
         }
 
         fromReference = false;

--- a/test/get-core/null.spec.js
+++ b/test/get-core/null.spec.js
@@ -1,41 +1,71 @@
-var getCoreRunner = require('./../getCoreRunner');
-var jsonGraph = require('falcor-json-graph');
-var atom = jsonGraph.atom;
-var ref = jsonGraph.ref;
-var NullInPathError = require('./../../lib/errors/NullInPathError');
+var getCoreRunner = require("./../getCoreRunner");
 
-describe('Nulls', function() {
-    it('should allow null at end of path.', function() {
+describe("Nulls", function() {
+    it("should allow null past end of path.", function() {
         getCoreRunner({
-            input: [['a', null]],
+            input: [["a", "b", "c", null]],
             output: {
                 json: {
-                    a: 'title'
-                }
+                    a: { b: { c: "title" } },
+                },
             },
             cache: {
-                a: ref(['b']),
-                b: 'title'
-            }
+                a: { b: { c: "title" } },
+            },
         });
     });
 
-    it('should throw an error if null is in middle of path.', function() {
-        expect(() => 
-            getCoreRunner({
-                input: [['a', null, 'c']],
-                output: {
-                    json: {
-                        a: 'title'
-                    }
+    it("should allow null at end of path.", function() {
+        getCoreRunner({
+            input: [["a", "b", null]],
+            output: {
+                json: {
+                    a: { b: {} },
                 },
-                cache: {
-                    a: ref(['b']),
-                    b: {
-                        c: 'title'
-                    }
-                }
-            })).toThrow(NullInPathError)
+            },
+            cache: {
+                a: { b: { c: "title" } },
+            },
+        });
+    });
+
+    it("should allow null in middle of path.", function() {
+        getCoreRunner({
+            input: [["a", null, "c"]],
+            output: {
+                json: {
+                    a: {},
+                },
+            },
+            cache: {
+                a: { b: { c: "title" } },
+            },
+        });
+    });
+
+    it("should allow null in key sets.", function() {
+        getCoreRunner({
+            input: [["a", [null, "b"], "c"]],
+            output: {
+                json: {
+                    a: { b: { c: "title" } },
+                },
+            },
+            cache: {
+                a: { b: { c: "title" } },
+            },
+        });
+
+        getCoreRunner({
+            input: [["a", ["b", null], "c"]],
+            output: {
+                json: {
+                    a: { b: { c: "title" } },
+                },
+            },
+            cache: {
+                a: { b: { c: "title" } },
+            },
+        });
     });
 });
-


### PR DESCRIPTION
As the title says. Throwing has proven to be of limited value, and is causing log spam and unhandled Promise rejections.