### PR TITLE
Enable GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 0.x
+      - 1.0.0
+  pull_request:
+    branches:
+      - master
+      - 0.x
+      - 1.0.0
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm update -g npm
+    - run: npm install
+    - run: npm run dist
+    - run: npm test
+    - run: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+      if: ${{ always() }}
+    - run: npm run deploy-ghpages
+      if: ${{ always() }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to [build and test Node.js](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs) based on the [current TravisCI configuration](https://github.com/Netflix/falcor/blob/master/.travis.yml).