### PR TITLE
Avoid fetching null paths

### DIFF
--- a/lib/get/walkPath.js
+++ b/lib/get/walkPath.js
@@ -44,10 +44,10 @@ module.exports = function walkPath(model, root, curr, path, depth, seed,
     // loop over every key in the key set
     do {
         if (key == null) {
-            // Skip null/undefined/empty keysets in path and do not descend, but capture the partial path in the result
-            onValueType(model, curr, path, depth, seed, outerResults, branchInfo,
-                requestedPath, optimizedPath, optimizedLength,
-                isJSONG, fromReference);
+            // Skip null/undefined/empty keysets in path and do not descend,
+            // but capture the partial path in the result
+            onValue(model, curr, seed, depth, outerResults, branchInfo,
+                    requestedPath, optimizedPath, optimizedLength, isJSONG);
 
             if (iteratorNote && !iteratorNote.done) {
                 key = iterateKeySet(keySet, iteratorNote);

--- a/test/get-core/edges.spec.js
+++ b/test/get-core/edges.spec.js
@@ -20,8 +20,6 @@ describe('Edges', function() {
                 }
             },
             cache: cacheGenerator(0, 1),
-            requestedMissingPaths: [],
-            optimizedMissingPaths: []
         });
     });
     it('should report an atom of undefined in non-progressive mode.', function() {


### PR DESCRIPTION
Missing paths were generated by the recent change to paths with null/undefined/empty key sets. This resulted in unnecessary network requests.