### PR TITLE
fix: always use public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.com

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/Netflix/falcor.git"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest --coverage --collectCoverageFrom='./lib/**/*.js'",


### PR DESCRIPTION
Two changes:

1. Always publish this to the public npm registry no matter local registry configs
2. Install packages from the public npm registry to prevent local registry configs from letting internal packages creep in.